### PR TITLE
fix(governed-brain): make clean marketplace installs self-starting

### DIFF
--- a/.claude-plugin/marketplace.extended.json
+++ b/.claude-plugin/marketplace.extended.json
@@ -10255,8 +10255,8 @@
     },    {
       "name": "governed-second-brain",
       "source": "./plugins/mcp/governed-second-brain",
-      "description": "Local-first governed second brain — turn your files into cited (qmd://) memory with deterministic governance and a tamper-evident, hash-chained audit trail. Install via `npx governed-second-brain init <folder>`.",
-      "version": "0.1.6",
+      "description": "Bob's Big Brain — governed, cited memory with local and team modes, deterministic promotion, and a tamper-evident audit trail.",
+      "version": "1.1.2",
       "category": "mcp",
       "keywords": [
         "memory",
@@ -10272,8 +10272,8 @@
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io"
       },
-      "homepage": "https://github.com/jeremylongshore/governed-second-brain-plugin",
-      "repository": "https://github.com/jeremylongshore/governed-second-brain-plugin",
+      "homepage": "https://github.com/jeremylongshore/bobs-big-brain-plugin",
+      "repository": "https://github.com/jeremylongshore/bobs-big-brain-plugin",
       "license": "Apache-2.0"
     },    {
       "name": "claudebase",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8691,8 +8691,8 @@
     {
       "name": "governed-second-brain",
       "source": "./plugins/mcp/governed-second-brain",
-      "description": "Local-first governed second brain — turn your files into cited (qmd://) memory with deterministic governance and a tamper-evident, hash-chained audit trail. Install via `npx governed-second-brain init <folder>`.",
-      "version": "0.1.6",
+      "description": "Bob's Big Brain — governed, cited memory with local and team modes, deterministic promotion, and a tamper-evident audit trail.",
+      "version": "1.1.2",
       "category": "mcp",
       "keywords": [
         "memory",
@@ -8708,8 +8708,8 @@
         "name": "Jeremy Longshore",
         "email": "jeremy@intentsolutions.io"
       },
-      "homepage": "https://github.com/jeremylongshore/governed-second-brain-plugin",
-      "repository": "https://github.com/jeremylongshore/governed-second-brain-plugin",
+      "homepage": "https://github.com/jeremylongshore/bobs-big-brain-plugin",
+      "repository": "https://github.com/jeremylongshore/bobs-big-brain-plugin",
       "license": "Apache-2.0"
     },
     {

--- a/.gitignore
+++ b/.gitignore
@@ -170,6 +170,7 @@ marketplace/src/data/cowork-manifest.json
 node_modules/
 npm-debug.log
 package-lock.json
+!plugins/mcp/governed-second-brain/plugin-runtime/package-lock.json
 playwright-report/
 playwright/.cache/
 reports/

--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ Jump to any of the 19 categories below. Plugin counts are catalog totals — aut
 | `design-to-code`              | Convert Figma designs and screenshots to React/Svelte/Vue components with built-in accessibility                                            |
 | `dolt-mcp-vcs`                | Dolt/DoltHub version-control toolkit for Claude Code, via the dolthub/dolt-mcp server — a VC-surface skill + expert agents over a Dolt…     |
 | `domain-memory-agent`         | Knowledge base with TF-IDF semantic search and extractive summarization - no ML dependencies required                                       |
-| `governed-second-brain`       | Local-first governed second brain — turn your files into cited (qmd://) memory with deterministic governance and a tamper-evident,…         |
+| `governed-second-brain`       | Bob's Big Brain — governed, cited memory with local and team modes, deterministic promotion, and a tamper-evident audit trail.              |
 | `lumera-agent-memory`         | Durable agent memory with Cascade object storage, client-side encryption, and local full-text search index. Persists agent context across…  |
 | `pr-to-spec`                  | The flight envelope for agentic coding — convert PRs and local diffs into structured, agent-consumable specs with intent drift detection    |
 | `project-health-auditor`      | Multi-dimensional code health analysis with complexity, churn, and test coverage - identifies technical debt hot spots                      |

--- a/plugins/mcp/governed-second-brain/.claude-plugin/marketplace.json
+++ b/plugins/mcp/governed-second-brain/.claude-plugin/marketplace.json
@@ -4,15 +4,32 @@
     "name": "Jeremy Longshore",
     "email": "jeremy@intentsolutions.io"
   },
+  "metadata": {
+    "description": "Bob's Big Brain — the installable governed second brain for Claude Code and Cowork. Cited (qmd://) recall + governed capture with a tamper-evident SHA-256 hash-chained audit trail. One plugin, two modes: local (in-process over your own files) or team (your team's single governed brain over the tailnet).",
+    "version": "1.1.2"
+  },
   "plugins": [
     {
       "name": "governed-second-brain",
       "source": ".",
-      "description": "Bob's Big Brain — the governed team brain: cited recall, hash-chained receipts. ONE plugin, two modes. Local (default): turn your own files into cited (qmd://) memory with deterministic governance and a tamper-evident SHA-256 hash-chained audit trail, in-process, no network. Team (set TEAMKB_API_URL): query your team's single governed brain over the tailnet.",
-      "version": "1.1.0",
+      "description": "Bob's Big Brain \u2014 the governed team brain: cited recall, hash-chained receipts. ONE plugin, two modes. Local provisions two pinned native modules once, then runs in-process; team queries your shared governed brain over the tailnet.",
+      "version": "1.1.2",
       "category": "productivity",
-      "keywords": ["memory", "knowledge", "governance", "qmd", "citations", "local-first", "team", "tailnet", "second-brain"],
-      "author": "Jeremy Longshore",
+      "keywords": [
+        "memory",
+        "knowledge",
+        "governance",
+        "qmd",
+        "citations",
+        "local-first",
+        "team",
+        "tailnet",
+        "second-brain"
+      ],
+      "author": {
+        "name": "Jeremy Longshore",
+        "email": "jeremy@intentsolutions.io"
+      },
       "license": "Apache-2.0"
     }
   ]

--- a/plugins/mcp/governed-second-brain/.claude-plugin/plugin.json
+++ b/plugins/mcp/governed-second-brain/.claude-plugin/plugin.json
@@ -1,13 +1,13 @@
 {
   "name": "governed-second-brain",
-  "version": "1.1.0",
-  "description": "Bob's Big Brain — the governed team brain: cited recall, hash-chained receipts. ONE plugin, two modes. Local (default): turn your own files into cited (qmd://) memory, every write run through deterministic governance and a tamper-evident SHA-256 hash-chained audit trail, in-process, no daemon, no network. Team (set TEAMKB_API_URL): query your team's single governed brain over the tailnet with a per-user token. Same /brain and /brain-save skills in both modes.",
+  "version": "1.1.2",
+  "description": "Bob's Big Brain \u2014 the governed team brain: cited recall, hash-chained receipts. ONE plugin, two modes. Local (default): turn your own files into cited (qmd://) memory with deterministic governance and a tamper-evident SHA-256 hash-chained audit trail, in-process with no runtime network after one-time native dependency provisioning. Team (set TEAMKB_API_URL): query your team's single governed brain over the tailnet with a per-user token.",
   "author": {
     "name": "Jeremy Longshore",
     "email": "jeremy@intentsolutions.io"
   },
-  "homepage": "https://github.com/jeremylongshore/governed-second-brain-plugin",
-  "repository": "https://github.com/jeremylongshore/governed-second-brain-plugin",
+  "homepage": "https://github.com/jeremylongshore/bobs-big-brain-plugin",
+  "repository": "https://github.com/jeremylongshore/bobs-big-brain-plugin",
   "license": "Apache-2.0",
   "keywords": [
     "memory",
@@ -23,15 +23,18 @@
   "mcpServers": {
     "governed-brain": {
       "name": "governed-brain",
-      "description": "Bob's Big Brain — ONE plugin, two modes. Local (default): an in-process governed brain over your own files (~/.teamkb) — cited search plus governed capture → govern → promote with a SHA-256 hash-chained audit trail, no daemon, no network. Team (set TEAMKB_API_URL): a remote proxy to your team's single governed brain over the tailnet, with a per-user token. Mode is auto-detected from TEAMKB_API_URL.",
-      "version": "1.1.0",
+      "description": "Bob's Big Brain \u2014 ONE plugin, two modes. Local (default): an in-process governed brain over your own files (~/.teamkb); first start provisions two lockfile-pinned native modules, then runtime is local. Team (set TEAMKB_API_URL): a dependency-free remote proxy to your team's single governed brain over the tailnet, with a per-user token.",
+      "version": "1.1.2",
       "enabled": true,
       "transport": "stdio",
       "command": "node",
-      "args": ["${CLAUDE_PLUGIN_ROOT}/plugin-runtime/governed-brain.cjs"],
+      "args": [
+        "${CLAUDE_PLUGIN_ROOT}/plugin-runtime/bootstrap.cjs"
+      ],
       "env": {
         "TEAMKB_API_URL": "${TEAMKB_API_URL:-}",
-        "TEAMKB_API_TOKEN": "${TEAMKB_API_TOKEN:-}"
+        "TEAMKB_API_TOKEN": "${TEAMKB_API_TOKEN:-}",
+        "TEAMKB_TENANT_ID": "${TEAMKB_TENANT_ID:-}"
       }
     }
   }

--- a/plugins/mcp/governed-second-brain/.mcp.json
+++ b/plugins/mcp/governed-second-brain/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "governed-brain": {
       "name": "governed-brain",
-      "description": "Bob's Big Brain \u2014 ONE plugin, two modes. Local (default): an in-process governed brain over your own files (~/.teamkb). Team (set TEAMKB_API_URL + TEAMKB_API_TOKEN + TEAMKB_TENANT_ID): a remote proxy to your team's single governed brain over the tailnet. This root .mcp.json is the PROJECT-scope config (relative path); marketplace installs use .claude-plugin/plugin.json (which resolves ${CLAUDE_PLUGIN_ROOT}).",
+      "description": "Bob's Big Brain \u2014 ONE plugin, two modes. Local (default): an in-process governed brain over your own files (~/.teamkb). Team (set TEAMKB_API_URL + TEAMKB_API_TOKEN + TEAMKB_TENANT_ID): a remote proxy to your team's single governed brain over the tailnet. This root .mcp.json is the project-scope config with a relative path; marketplace installs resolve the plugin root from their manifest.",
       "version": "1.1.2",
       "enabled": true,
       "transport": "stdio",

--- a/plugins/mcp/governed-second-brain/.mcp.json
+++ b/plugins/mcp/governed-second-brain/.mcp.json
@@ -2,15 +2,18 @@
   "mcpServers": {
     "governed-brain": {
       "name": "governed-brain",
-      "description": "Governed second brain — ONE plugin, two modes. Local (default): an in-process governed brain over your own files (~/.teamkb) — cited search plus governed capture → govern → promote with a SHA-256 hash-chained audit trail, no daemon, no network. Team (set TEAMKB_API_URL): a remote proxy to your team's single governed brain over the tailnet, with a per-user token. Mode is auto-detected from TEAMKB_API_URL.",
-      "version": "1.1.0",
+      "description": "Bob's Big Brain \u2014 ONE plugin, two modes. Local (default): an in-process governed brain over your own files (~/.teamkb). Team (set TEAMKB_API_URL + TEAMKB_API_TOKEN + TEAMKB_TENANT_ID): a remote proxy to your team's single governed brain over the tailnet. This root .mcp.json is the PROJECT-scope config (relative path); marketplace installs use .claude-plugin/plugin.json (which resolves ${CLAUDE_PLUGIN_ROOT}).",
+      "version": "1.1.2",
       "enabled": true,
       "transport": "stdio",
       "command": "node",
-      "args": ["${CLAUDE_PLUGIN_ROOT}/plugin-runtime/governed-brain.cjs"],
+      "args": [
+        "plugin-runtime/bootstrap.cjs"
+      ],
       "env": {
         "TEAMKB_API_URL": "${TEAMKB_API_URL:-}",
-        "TEAMKB_API_TOKEN": "${TEAMKB_API_TOKEN:-}"
+        "TEAMKB_API_TOKEN": "${TEAMKB_API_TOKEN:-}",
+        "TEAMKB_TENANT_ID": "${TEAMKB_TENANT_ID:-}"
       }
     }
   }

--- a/plugins/mcp/governed-second-brain/.source.json
+++ b/plugins/mcp/governed-second-brain/.source.json
@@ -4,22 +4,21 @@
     "path": ".",
     "branch": "main"
   },
-  "last_sync": "2026-07-13T17:26:52.921Z",
+  "last_sync": "2026-07-16T06:12:34.920Z",
   "author": {
     "name": "Jeremy Longshore",
     "github": "jeremylongshore",
     "email": "jeremy@intentsolutions.io"
   },
   "license": "Apache-2.0",
-  "files_synced": 12,
+  "files_synced": 11,
   "files": [
     ".claude-plugin/marketplace.json",
     ".claude-plugin/plugin.json",
     ".mcp.json",
     "LICENSE",
     "README.md",
-    "hooks/README.md",
-    "onboarding/README.md",
+    "plugin-runtime/bootstrap.cjs",
     "plugin-runtime/governed-brain.cjs",
     "plugin-runtime/package-lock.json",
     "plugin-runtime/package.json",

--- a/plugins/mcp/governed-second-brain/.source.json
+++ b/plugins/mcp/governed-second-brain/.source.json
@@ -4,7 +4,7 @@
     "path": ".",
     "branch": "main"
   },
-  "last_sync": "2026-07-16T06:30:06.353Z",
+  "last_sync": "2026-07-16T06:44:55.519Z",
   "author": {
     "name": "Jeremy Longshore",
     "github": "jeremylongshore",

--- a/plugins/mcp/governed-second-brain/.source.json
+++ b/plugins/mcp/governed-second-brain/.source.json
@@ -1,10 +1,10 @@
 {
   "synced_from": {
-    "repo": "jeremylongshore/governed-second-brain-plugin",
+    "repo": "jeremylongshore/bobs-big-brain-plugin",
     "path": ".",
     "branch": "main"
   },
-  "last_sync": "2026-07-16T06:12:34.920Z",
+  "last_sync": "2026-07-16T06:30:06.353Z",
   "author": {
     "name": "Jeremy Longshore",
     "github": "jeremylongshore",

--- a/plugins/mcp/governed-second-brain/README.md
+++ b/plugins/mcp/governed-second-brain/README.md
@@ -157,7 +157,7 @@ network); **Claude Desktop** can, via a manual `mcpServers` config (see below). 
    team mode:
    ```json
    {
-     "apiUrl": "http://your-team-brain:3847",
+    "apiUrl": "http://localhost:3847",
      "apiToken": "<your per-user token>",
      "tenantId": "<your tenant, e.g. intent-solutions>"
    }

--- a/plugins/mcp/governed-second-brain/README.md
+++ b/plugins/mcp/governed-second-brain/README.md
@@ -4,7 +4,7 @@
   The governed team brain — cited recall, hash-chained receipts. A local-first Claude Code + Cowork
   plugin: turn <em>your own</em> files into a governed, <code>qmd://</code>-cited brain with a
   tamper-evident, SHA-256 hash-chained audit trail.<br>
-  <strong>Compile, then govern.</strong> One plugin, two modes: <strong>local</strong> (default — in-process, no daemon, no network, no API key for retrieval) or <strong>team</strong> (proxy to a shared governed brain over your network).
+  <strong>Compile, then govern.</strong> One plugin, two modes: <strong>local</strong> (default — in-process, no daemon, no runtime network after first-start provisioning, no API key for retrieval) or <strong>team</strong> (proxy to a shared governed brain over your network).
 </p>
 
 <p align="center">
@@ -20,7 +20,7 @@
 | | Repo | What it is |
 |---|---|---|
 | **Landing / thesis** | **[intent-solutions-io/governed-second-brain](https://github.com/intent-solutions-io/governed-second-brain)** | The umbrella — *why* this exists, the competitive teardown, the "Compile, Then Govern" thesis, the receipts argument. Start here for the **story**. |
-| **The plugin** (you are here) | **[jeremylongshore/governed-second-brain-plugin](https://github.com/jeremylongshore/governed-second-brain-plugin)** | The installable code — the local stdio MCP server + skills. Start here to **run it**. |
+| **The plugin** (you are here) | **[jeremylongshore/bobs-big-brain-plugin](https://github.com/jeremylongshore/bobs-big-brain-plugin)** | The installable code — the local stdio MCP server + skills. Start here to **run it**. |
 
 It stacks on three engines:
 
@@ -28,10 +28,12 @@ It stacks on three engines:
 |---|---|---|
 | **ICO** | [jeremylongshore/intentional-cognition-os](https://github.com/jeremylongshore/intentional-cognition-os) | **Compile** — derive knowledge from a corpus (optional; the only part that egresses) |
 | **INTKB** | [jeremylongshore/qmd-team-intent-kb](https://github.com/jeremylongshore/qmd-team-intent-kb) | **Govern** — deterministic dedupe → policy → promote + the hash-chained audit |
-| **qmd** | [tobi/qmd](https://github.com/tobi/qmd) | **Retrieve** — on-device search; every hit is a `qmd://` citation |
+| **qmd** | [tobi/qmd](https://github.com/tobi/qmd) (`@tobilu/qmd`) | **Retrieve** — on-device search; every hit is a `qmd://` citation |
 
 This plugin **bundles** the compiled INTKB packages, so it runs the govern + retrieve loop fully
 in-process — the engines stay independent repos; nothing here forks or privatizes them.
+
+**Powered by [tobi/qmd](https://github.com/tobi/qmd).** We pin `@tobilu/qmd` and ride upstream via Dependabot — we do **not** fork the search engine. For the **team** index (not personal `~/.cache/qmd`), operators on an INTKB checkout use `./scripts/bbb-qmd` and `pnpm search-canary` (see [qmd-team-intent-kb ops runbook](https://github.com/jeremylongshore/qmd-team-intent-kb/blob/main/000-docs/042-OD-OPSM-bbb-qmd-operator-runbook.md)).
 
 ## What it does
 
@@ -101,6 +103,11 @@ history-rewrite failure. Run the verifier's own tests with `npm run verify-ancho
 
 ## Install
 
+Local-mode marketplace installs provision two lockfile-pinned native modules (`better-sqlite3` and
+`fs-ext`) inside the plugin on first start. That one-time step uses npm; after it completes, local
+capture, governance, audit, and retrieval run in-process without a service daemon. Team mode does not
+load or install those local-store modules.
+
 One command, two modes:
 
 ```bash
@@ -132,10 +139,41 @@ You need network reachability to that API — typically a private network / VPN 
 (the brain is meant to stay off the public internet). The dispatcher auto-detects mode from
 `TEAMKB_API_URL`: set → team, unset → local. Same `/brain` + `/brain-save` skills either way.
 
-In team mode the tool surface is **`brain_search`** (read) + **`brain_capture`** (propose) +
-**`brain_transition`** (admin-only) — govern runs server-side, so there's no client `brain_govern`:
-**the model proposes, the server disposes**, and each promotion gets a hash-chained receipt. A member
-token can read + propose; admin actions (transition) return a clear 403 otherwise.
+#### Install it as a team member
+
+The plugin runs in **Claude Code** or **Cowork** — the same install in both. It **cannot** run in
+claude.ai in a web browser or the phone apps (a browser tab can't reach a local plugin or a private
+network); **Claude Desktop** can, via a manual `mcpServers` config (see below). On macOS **or** Windows:
+
+1. **Join the team network** (Tailscale) so your machine can reach the brain's API.
+2. **Add the plugin** — in Claude Code or Cowork. It's a public repo, so no org membership or `gh`
+   login is needed:
+   ```
+   /plugin marketplace add jeremylongshore/bobs-big-brain-plugin
+   /plugin install governed-second-brain@governed-second-brain
+   ```
+3. **Save your connection** to `~/.teamkb/team.json` (Windows: `%USERPROFILE%\.teamkb\team.json`) at
+   mode `600`. This file is read **before** shell env vars, so a Dock/GUI-launched Claude still reaches
+   team mode:
+   ```json
+   {
+     "apiUrl": "http://your-team-brain:3847",
+     "apiToken": "<your per-user token>",
+     "tenantId": "<your tenant, e.g. intent-solutions>"
+   }
+   ```
+4. **Restart the app**, then ask with **keywords** (retrieval is keyword-based, so strong words beat a
+   full sentence): `/brain shipped this week`. A cited `qmd://` answer means you're connected.
+
+macOS + Claude Code has a one-click installer that does steps 2–3 for you, and there's a full
+per-platform walkthrough (incl. the **Claude Desktop** `mcpServers` config) in
+[`onboarding/`](onboarding/README.md).
+
+In team mode the tool surface is **`brain_search`** + **`brain_status`** (read),
+**`brain_capture`** (propose), and **`brain_inbox`** / **`brain_approve`** / **`brain_reject`** /
+**`brain_transition`** (admin review and lifecycle). Govern runs server-side, so there's no client
+`brain_govern`: **the model proposes, the server disposes**, and each promotion gets a hash-chained
+receipt. A member token can read + propose; admin actions return a clear 403 otherwise.
 
 > Team mode is **dependency-free** — it uses only `fetch` + the MCP SDK, never the native store — so it
 > runs straight from a marketplace clone with zero build.

--- a/plugins/mcp/governed-second-brain/package.json
+++ b/plugins/mcp/governed-second-brain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intentsolutionsio/governed-second-brain",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "A local-first governed second brain for Claude Code — turn your own files into cited (qmd://) memory, with every write run through deterministic governance and recorded in a tamper-evident, SHA-256 ha",
   "keywords": [
     "memory",

--- a/plugins/mcp/governed-second-brain/plugin-runtime/bootstrap.cjs
+++ b/plugins/mcp/governed-second-brain/plugin-runtime/bootstrap.cjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Marketplace-safe launcher for the committed MCP bundle.
+ *
+ * Claude/Codex plugin installs copy files but do not run this repository's npm
+ * installer. Team mode is dependency-free, while local mode needs the two
+ * native modules externalized by build.mjs. Provision those exact, lockfile-
+ * pinned modules on first local start, then execute the bundled server.
+ */
+const { createRequire } = require('node:module');
+const { existsSync, mkdirSync, rmSync, statSync } = require('node:fs');
+const { homedir } = require('node:os');
+const { join } = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const RUNTIME_DIR = __dirname;
+const BUNDLE = join(RUNTIME_DIR, 'governed-brain.cjs');
+const LOCK_DIR = join(RUNTIME_DIR, '.native-install.lock');
+const LOCK_STALE_MS = 5 * 60 * 1000;
+const WAIT_LIMIT_MS = 2 * 60 * 1000;
+const WAIT_STEP_MS = 250;
+
+function isConfigured(value) {
+  const normalized = value?.trim();
+  return normalized !== undefined && normalized !== '' && !normalized.startsWith('${');
+}
+
+function teamConfigPath(env = process.env) {
+  const base = env.TEAMKB_BASE_PATH?.trim() || env.TEAMKB_HOME?.trim() || join(homedir(), '.teamkb');
+  return join(base, 'team.json');
+}
+
+function teamModeRequested(env = process.env) {
+  return isConfigured(env.TEAMKB_API_URL) || existsSync(teamConfigPath(env));
+}
+
+function nativeDependenciesReady() {
+  try {
+    const runtimeRequire = createRequire(BUNDLE);
+    runtimeRequire('better-sqlite3');
+    runtimeRequire('fs-ext');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function sleep(milliseconds) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
+function acquireInstallLock() {
+  const started = Date.now();
+  while (true) {
+    try {
+      mkdirSync(LOCK_DIR);
+      return true;
+    } catch (error) {
+      if (error?.code !== 'EEXIST') throw error;
+      if (nativeDependenciesReady()) return false;
+      try {
+        if (Date.now() - statSync(LOCK_DIR).mtimeMs > LOCK_STALE_MS) {
+          rmSync(LOCK_DIR, { recursive: true, force: true });
+          continue;
+        }
+      } catch (statError) {
+        if (statError?.code !== 'ENOENT') throw statError;
+        continue;
+      }
+      if (Date.now() - started > WAIT_LIMIT_MS) {
+        throw new Error('timed out waiting for another governed-brain native dependency install');
+      }
+      sleep(WAIT_STEP_MS);
+    }
+  }
+}
+
+function provisionNativeDependencies() {
+  if (nativeDependenciesReady()) return;
+  const ownsLock = acquireInstallLock();
+  if (!ownsLock) return;
+  try {
+    if (nativeDependenciesReady()) return;
+    process.stderr.write('[governed-brain] first local start: provisioning lockfile-pinned native runtime dependencies\n');
+    const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+    const result = spawnSync(
+      npm,
+      ['ci', '--omit=dev', '--no-audit', '--no-fund'],
+      { cwd: RUNTIME_DIR, stdio: ['ignore', 'ignore', 'inherit'], timeout: WAIT_LIMIT_MS },
+    );
+    if (result.error) throw result.error;
+    if (result.status !== 0) throw new Error(`npm ci exited ${result.status ?? 'without a status'}`);
+    if (!nativeDependenciesReady()) {
+      throw new Error('native dependencies are still unavailable after npm ci');
+    }
+  } finally {
+    rmSync(LOCK_DIR, { recursive: true, force: true });
+  }
+}
+
+function main() {
+  if (!existsSync(BUNDLE)) throw new Error(`bundled MCP runtime missing: ${BUNDLE}`);
+  // A valid or invalid team.json both belong to the dependency-free team path.
+  // The bundle remains authoritative for parsing it and failing closed.
+  if (!teamModeRequested()) provisionNativeDependencies();
+  require(BUNDLE);
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`[governed-brain] REFUSING TO START — ${error?.message || String(error)}\n`);
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  isConfigured,
+  nativeDependenciesReady,
+  provisionNativeDependencies,
+  teamConfigPath,
+  teamModeRequested,
+};

--- a/plugins/mcp/governed-second-brain/plugin-runtime/governed-brain.cjs
+++ b/plugins/mcp/governed-second-brain/plugin-runtime/governed-brain.cjs
@@ -35560,7 +35560,15 @@ function uuidv5(name, namespace) {
   const x = h.toString("hex");
   return `${x.slice(0, 8)}-${x.slice(8, 12)}-${x.slice(12, 16)}-${x.slice(16, 20)}-${x.slice(20, 32)}`;
 }
-function deriveCandidateId(tenant, title, content) {
+function deriveCandidateId(tenant, title, content, sessionId, learningIndex) {
+  const sid = sessionId?.trim();
+  if (sid !== void 0 && sid !== "") {
+    const idx = typeof learningIndex === "number" && Number.isInteger(learningIndex) && learningIndex >= 0 ? learningIndex : 0;
+    return uuidv5(`${tenant}
+${sid}
+session-end
+${idx}`, CANDIDATE_ID_NAMESPACE);
+  }
   return uuidv5(`${tenant}
 ${title}
 ${content}`, CANDIDATE_ID_NAMESPACE);
@@ -35573,7 +35581,8 @@ async function enqueueOutbox(candidate) {
   const dir = outboxDir();
   try {
     await (0, import_promises.mkdir)(dir, { recursive: true, mode: 448 });
-    await (0, import_promises.writeFile)((0, import_node_path2.join)(dir, `${candidate.id}.json`), JSON.stringify(candidate), { mode: 384 });
+    const body = JSON.stringify(candidate);
+    await (0, import_promises.writeFile)((0, import_node_path2.join)(dir, `${candidate.id}.json`), body, { mode: 384 });
     return true;
   } catch (e) {
     process.stderr.write(
@@ -35646,7 +35655,11 @@ async function search(query, scope, limit) {
     res = await fetch(url, {
       method: "POST",
       headers: authHeaders(),
-      body: JSON.stringify({ query, scope, pagination: { page: 1, pageSize: limit } })
+      // Send the tenant — the API's /api/search scopes qmd by tenantId and returns
+      // ZERO hits without it (unlike capture, which carried tenantId in the candidate).
+      // TENANT_ID defaults to the shared 'intent-solutions' tenant; a scoped teammate
+      // token still has its tenantId validated server-side by the tenancy guard.
+      body: JSON.stringify({ query, scope, tenantId: TENANT_ID, pagination: { page: 1, pageSize: limit } })
     });
   } catch (e) {
     return jsonResult({
@@ -35700,12 +35713,12 @@ async function status() {
   }
   return jsonResult({ mode: "team", apiUrl, tokenSet, healthy: res.ok, version });
 }
-async function capture(title, content, category, filePaths) {
+async function capture(title, content, category, filePaths, sessionId, learningIndex) {
   if (API_URL === void 0 || API_URL === "") {
     return jsonResult({ ok: false, error: "unconfigured \u2014 set TEAMKB_API_URL to your team brain" });
   }
   const candidate = {
-    id: deriveCandidateId(TENANT_ID, title, content),
+    id: deriveCandidateId(TENANT_ID, title, content, sessionId, learningIndex),
     status: "inbox",
     source: "mcp",
     content,
@@ -35714,16 +35727,22 @@ async function capture(title, content, category, filePaths) {
     trustLevel: "medium",
     author: { type: "ai", id: "governed-brain" },
     tenantId: TENANT_ID,
-    metadata: { filePaths: filePaths ?? [], tags: [] },
+    metadata: {
+      filePaths: filePaths ?? [],
+      tags: [],
+      ...sessionId?.trim() ? { sessionId: sessionId.trim() } : {},
+      ...typeof learningIndex === "number" && Number.isInteger(learningIndex) ? { learningIndex } : {}
+    },
     prePolicyFlags: { potentialSecret: false, lowConfidence: false, duplicateSuspect: false },
     capturedAt: (/* @__PURE__ */ new Date()).toISOString()
   };
+  const body = JSON.stringify(candidate);
   let res;
   try {
     res = await fetch(`${API_URL.replace(/\/+$/, "")}/api/candidates`, {
       method: "POST",
       headers: authHeaders(),
-      body: JSON.stringify(candidate)
+      body
     });
   } catch (e) {
     const queued = await enqueueOutbox(candidate);
@@ -35748,13 +35767,28 @@ async function capture(title, content, category, filePaths) {
     }
     return errorResult(res);
   }
+  let intake;
+  try {
+    const text = await res.text();
+    try {
+      const parsed = JSON.parse(text);
+      if (typeof parsed.intake === "string") intake = parsed.intake;
+    } catch {
+    }
+  } catch {
+    intake = void 0;
+  }
   const drained = await drainOutbox();
+  const known = intake === "created" || intake === "already_exists" ? intake : res.status === 201 ? "created" : "unknown";
+  const already = known === "already_exists";
   return jsonResult({
     ok: true,
     candidateId: candidate.id,
     tenantId: TENANT_ID,
+    intake: known,
+    alreadyExists: already,
     ...drained > 0 ? { outboxDrained: drained } : {},
-    message: "Proposed to the team brain inbox. This is a PROPOSAL \u2014 the deterministic govern pipeline decides if/when it is promoted (an admin governs, or auto-govern once enabled). It is not durable memory yet."
+    message: already ? "Idempotent: this proposal already exists in the team brain inbox (same session slot or same content). Safe to retry; not a new capture." : known === "unknown" ? "Proposed to the team brain inbox (server did not report created vs already_exists). This is a PROPOSAL \u2014 not durable memory until promoted." : "Proposed to the team brain inbox. This is a PROPOSAL \u2014 the deterministic govern pipeline decides if/when it is promoted (an admin governs, or auto-govern once enabled). It is not durable memory yet."
   });
 }
 function resolveTenant(tenantId) {
@@ -35911,14 +35945,27 @@ var init_remote_server = __esm({
     );
     server.tool(
       "brain_capture",
-      "Propose a fact, decision, pattern, or convention to your team's governed brain \u2014 a PROPOSAL, not a promotion. Member-allowed: the server queues it as a candidate and the deterministic govern pipeline disposes; it is not durable memory until promoted. Proxies to the brain over the tailnet (team mode).",
+      "Propose a fact, decision, pattern, or convention to your team's governed brain \u2014 a PROPOSAL, not a promotion. Member-allowed: the server queues it as a candidate and the deterministic govern pipeline disposes; it is not durable memory until promoted. Proxies to the brain over the tailnet (team mode). For SessionEnd: pass sessionId + learningIndex (0..4) so each learning is its own slot and re-distill of that slot collapses.",
       {
         title: import_zod2.z.string().min(1).describe("Short, specific title for the memory"),
         content: import_zod2.z.string().min(1).describe("The fact to remember, in full"),
         category: import_zod2.z.enum(CATEGORIES).optional().describe("Memory category (default: reference)"),
-        filePaths: import_zod2.z.array(import_zod2.z.string()).optional().describe("Related file paths, if any")
+        filePaths: import_zod2.z.array(import_zod2.z.string()).optional().describe("Related file paths, if any"),
+        sessionId: import_zod2.z.string().optional().describe(
+          "Stable session id (Claude Code session). With learningIndex, forms a per-learning slot so re-distill does not duplicate and multi-learning sessions keep separate rows."
+        ),
+        learningIndex: import_zod2.z.number().int().min(0).max(4).optional().describe(
+          "0-based index of this learning within the session (SessionEnd: 0..4 for up to 5 learnings). Defaults to 0 when sessionId is set."
+        )
       },
-      async (params) => capture(params.title, params.content, params.category, params.filePaths)
+      async (params) => capture(
+        params.title,
+        params.content,
+        params.category,
+        params.filePaths,
+        params.sessionId,
+        params.learningIndex
+      )
     );
     server.tool(
       "brain_transition",
@@ -39319,6 +39366,20 @@ var init_governed_brain_v1 = __esm({
   }
 });
 
+// ../qmd-team-intent-kb/packages/qmd-adapter/dist/eval/datasets/synthetic-v1.js
+var SYNTHETIC_V1_BASELINE;
+var init_synthetic_v1 = __esm({
+  "../qmd-team-intent-kb/packages/qmd-adapter/dist/eval/datasets/synthetic-v1.js"() {
+    "use strict";
+    SYNTHETIC_V1_BASELINE = {
+      /** 8/8 lexical queries hit. */
+      lexicalRecallAtK: 1,
+      /** 7/12 semantic queries hit. */
+      semanticRecallAtK: 7 / 12
+    };
+  }
+});
+
 // ../qmd-team-intent-kb/packages/qmd-adapter/dist/eval/index.js
 var init_eval = __esm({
   "../qmd-team-intent-kb/packages/qmd-adapter/dist/eval/index.js"() {
@@ -39329,6 +39390,7 @@ var init_eval = __esm({
     init_stratified_report();
     init_qmd_retrieval();
     init_governed_brain_v1();
+    init_synthetic_v1();
   }
 });
 

--- a/plugins/mcp/governed-second-brain/plugin-runtime/package-lock.json
+++ b/plugins/mcp/governed-second-brain/plugin-runtime/package-lock.json
@@ -1,0 +1,486 @@
+{
+  "name": "governed-second-brain-runtime",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "governed-second-brain-runtime",
+      "version": "1.0.0",
+      "dependencies": {
+        "better-sqlite3": "12.11.1",
+        "fs-ext": "2.1.1"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/fs-ext": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fs-ext/-/fs-ext-2.1.1.tgz",
+      "integrity": "sha512-/TrISPOFhCkbgIRWK9lzscRzwPCu0PqtCcvMc9jsHKBgZGoqA0VzhspVht5Zu8lxaXjIYIBWILHpRotYkCCcQA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "nan": "^2.21.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/nan": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
+      "integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==",
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.94.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
+      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    }
+  }
+}

--- a/plugins/mcp/governed-second-brain/plugin-runtime/package.json
+++ b/plugins/mcp/governed-second-brain/plugin-runtime/package.json
@@ -5,6 +5,10 @@
   "description": "Self-contained native deps for the bundled governed-brain.cjs MCP runtime. build.mjs externalizes better-sqlite3/bindings/fs-ext (native addons, unbundleable); they are installed here so a copied/marketplace plugin-runtime/ works in LOCAL mode without relying on a parent node_modules. TEAM mode never loads sqlite.",
   "dependencies": {
     "better-sqlite3": "12.11.1",
-    "fs-ext": "^2.1.1"
+    "fs-ext": "2.1.1"
+  },
+  "allowScripts": {
+    "better-sqlite3@12.11.1": true,
+    "fs-ext@2.1.1": true
   }
 }

--- a/plugins/mcp/governed-second-brain/skills/brain-save/SKILL.md
+++ b/plugins/mcp/governed-second-brain/skills/brain-save/SKILL.md
@@ -66,8 +66,12 @@ genuinely-new delta:
    debugging steps, throwaway preferences, secrets, or anything already in a CLAUDE.md/README.
 2. Pick a category: `decision`, `pattern`, `convention`, `architecture`, `troubleshooting`,
    `onboarding`, or `reference`.
-3. Call **`brain_capture`** with `{ title, content, category, filePaths? }`. It appends the candidate to
-   the local spool (the model's *proposal*).
+3. Call **`brain_capture`** with `{ title, content, category, filePaths?, sessionId?, learningIndex? }`.
+   In **team mode**, SessionEnd/autocapture **must** pass `sessionId` + `learningIndex` (0..4) so each
+   learning is its own idempotency slot (re-distill of slot i collapses; slots stay distinct). For
+   one-off manual facts, omit both (id falls back to content). The team inbox **does** dedupe at
+   intake (id-first, then content-hash) — pre-save search still reduces noise. Local mode still
+   spool-captures as before.
 4. Call **`brain_govern`** to drain the spool through the deterministic pipeline (dedupe →
    policy/secret-detection → promotion). It returns what was promoted, rejected, flagged, and
    deduplicated, and writes the hash-chained audit event for each decision.

--- a/plugins/mcp/governed-second-brain/skills/brain/SKILL.md
+++ b/plugins/mcp/governed-second-brain/skills/brain/SKILL.md
@@ -9,10 +9,10 @@ description: |
   "what's my deploy runbook"). Trigger with "/brain", "ask the brain",
   "what do I know about", or "check my knowledge base".
 allowed-tools: 'mcp__governed-brain__brain_search'
-version: 1.0.0
+version: 1.2.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: Apache-2.0
-compatibility: 'Designed for Claude Code; ships with the governed-second-brain plugin, which auto-wires the governed-brain MCP server. Works in both modes: local (in-process, needs qmd on PATH) and team (proxies to your team brain when TEAMKB_API_URL is set). Same brain_search either way.'
+compatibility: 'Designed for Claude Code; ships with the bobs-big-brain (governed-brain) plugin, which auto-wires the governed-brain MCP server. Works in both modes: local (in-process, needs qmd on PATH) and team (proxies to your team brain when TEAMKB_API_URL is set). Same brain_search either way.'
 tags: [brain, knowledge, search, citations, governance, local-first, team]
 argument-hint: '[question]'
 ---
@@ -28,35 +28,54 @@ verifiable after the fact.
 
 This is the read surface of Bob's Big Brain: your files are **compiled** into
 governed memories, **governed** by deterministic code, and **retrieved** with citations
-by qmd. The `brain_search` MCP tool fronts that retrieval. The job here is to turn a
-natural-language question into a cited answer — and to refuse to answer beyond what the
-citations support.
+by **Tobi's qmd** (OSS). The `brain_search` MCP tool fronts that retrieval. Your product
+surround is INTKB govern + ICO compile + this plugin — not a fork of qmd.
+
+The job here is to turn a natural-language question into a cited answer — and to refuse
+to answer beyond what the citations support.
 
 ## Prerequisites
 
-- The `governed-second-brain` plugin is installed, which auto-wires the
-  `governed-brain` MCP server.
+- The **bobs-big-brain** / governed-brain plugin is installed (MCP `governed-brain`).
 - **Mode is automatic.** In **local mode** (default) search runs **in-process**
-  against your local `~/.teamkb` index — no network, no API key, no token; `qmd`
-  must be on your `PATH`. In **team mode** (when `TEAMKB_API_URL` is set) the same
-  `brain_search` proxies to your team's governed brain over the tailnet with your
-  per-user token; nothing extra is needed on your machine. Either way every hit is
-  a `qmd://` citation.
+  against your local `~/.teamkb` index — no network, no API key; a compatible **qmd**
+  binary must be available (prefer monorepo pin `@tobilu/qmd` via INTKB / installer).
+  Operators can use `scripts/bbb-qmd` from qmd-team-intent-kb so XDG points at the team
+  index, not personal `~/.cache/qmd`. In **team mode** (`TEAMKB_API_URL` set) search
+  proxies to the team brain. Every hit is a `qmd://` citation.
 
 ## Instructions
 
 ### Step 1: Search the governed corpus
 
-Call **`brain_search`** with the user's question as `query`. Keep `scope` at its
-default (`curated`) unless the user explicitly asks for inbox/archived material —
-curated is the governed, promoted knowledge.
+Retrieval is **Tobi's qmd** (BM25 keyword via the MCP). Prefer **short keyword queries**
+over full sentences.
+
+1. Derive **1–4 distinctive nouns/verbs** from the user question (drop what/why/how, articles,
+   auxiliaries, prepositions).
+2. Call **`brain_search`** with those keywords and `scope: "curated"` (default promoted knowledge).
 
 ```
-brain_search({ query: "the user's question, lightly cleaned up", scope: "curated" })
+brain_search({ query: "SOPS age secrets", scope: "curated" })
 ```
 
 The tool returns `{ source, results: [{ citation, snippet, score, collection }] }`.
 Each `citation` is a `qmd://COLLECTION/FILENAME` URI — the receipt for that hit.
+
+**Empty-result ladder (do not stop after one miss):**
+
+1. **Keyword retry (curated):** only if the first call was still a long natural-language sentence
+   (you skipped deriving 1–4 keywords). Re-run with 1–4 keywords only. **Skip this step** when the
+   first query was already keyword-style — do not re-call with the same tokens.
+2. **Scope retry (`all`):** if curated is still empty, re-run the **same keywords** with
+   `scope: "all"`. Do **not** use `inbox`/`archived` unless the user asks.
+3. Only after curated+keywords and all+keywords are empty → Step 3 (honest refuse).
+
+```
+brain_search({ query: "shipped week", scope: "curated" })
+// if empty (keywords already used):
+brain_search({ query: "shipped week", scope: "all" })
+```
 
 ### Step 2: Answer ONLY from the cited results
 
@@ -70,9 +89,9 @@ Each `citation` is a `qmd://COLLECTION/FILENAME` URI — the receipt for that hi
 
 ### Step 3: Handle an empty result honestly
 
-If `results` is empty, say so plainly: the brain has nothing governed on that topic.
-Do **not** fall back to general knowledge and present it as the brain's answer.
-Optionally note that the topic may need to be captured (run `/brain-save`).
+If `results` is **still** empty after the empty-result ladder in Step 1, say so plainly: the brain
+has nothing governed on that topic. Do **not** fall back to general knowledge and present it as the
+brain's answer. Optionally note that the topic may need to be captured (run `/brain-save`).
 
 ## Output
 
@@ -107,9 +126,9 @@ Sources:
 
 | Situation                                | Response                                                                                  |
 | ---------------------------------------- | ----------------------------------------------------------------------------------------- |
-| `brain_search` returns empty `results`   | State the brain has nothing governed; do not fabricate.                                    |
-| `qmd` is not on `PATH`                    | Retrieval is degraded (the server returns empty rather than crashing). Tell the user to install qmd 2.x on PATH. |
-| MCP tool unavailable                     | The plugin/MCP server is not enabled; tell the user to install/enable `governed-second-brain`. |
+| `brain_search` returns empty `results`   | Run the empty-result ladder (keywords → scope all); only then refuse. Do not fabricate. |
+| `qmd` missing / index empty              | Retrieval degrades to empty. Tell operator: install `@tobilu/qmd`, run INTKB `pnpm search-canary -- --heal` or `bbb-qmd status`. |
+| MCP tool unavailable                     | Plugin not enabled; install/enable bobs-big-brain / governed-brain. |
 | User asks to write/capture               | Out of scope here — direct them to `/brain-save`.                                          |
 
 ## Guardrails
@@ -118,9 +137,13 @@ Sources:
   `/brain-save`.
 - Never invent a qmd:// URI. Cite only URIs returned by `brain_search`.
 - Prefer fewer, well-cited claims over a broad answer that cannot be anchored.
+- Do not conflate this product with IRSB / Moat / Scout (separate stack).
 
 ## Resources
 
-- [Bob's Big Brain](https://github.com/intent-solutions-io/governed-second-brain) — the stack this brain belongs to.
-- [intentional-cognition-os](https://github.com/jeremylongshore/intentional-cognition-os) — the compiler (ICO).
+- [Bob's Big Brain umbrella](https://github.com/intent-solutions-io/bobs-big-brain-umbrella) — stack map.
+- [bobs-big-brain-plugin](https://github.com/jeremylongshore/bobs-big-brain-plugin) — this plugin.
+- [qmd-team-intent-kb](https://github.com/jeremylongshore/qmd-team-intent-kb) — govern layer + `bbb-qmd`.
+- [tobi/qmd](https://github.com/tobi/qmd) (npm `@tobilu/qmd`) — retrieve engine (OSS; we pin, we do not fork).
+- [intentional-cognition-os](https://github.com/jeremylongshore/intentional-cognition-os) — compile layer (ICO).
 - The write counterpart: the `/brain-save` skill (governed capture).

--- a/scripts/check-package-manager.mjs
+++ b/scripts/check-package-manager.mjs
@@ -43,6 +43,25 @@ function checkForbiddenLockfiles() {
       const marketplacePkg = join(ROOT, 'marketplace', 'package.json');
       return existsSync(marketplacePkg);
     }
+    if (
+      filename === 'package-lock.json' &&
+      relPath ===
+        join('plugins', 'mcp', 'governed-second-brain', 'plugin-runtime', 'package-lock.json')
+    ) {
+      // This is a copied, self-contained Node runtime rather than a pnpm
+      // workspace package. Its first-start bootstrap invokes npm ci against
+      // this exact lockfile so native addons are reproducible after a
+      // marketplace file-copy install.
+      const runtimePkg = join(
+        ROOT,
+        'plugins',
+        'mcp',
+        'governed-second-brain',
+        'plugin-runtime',
+        'package.json',
+      );
+      return existsSync(runtimePkg);
+    }
     return false;
   }
 

--- a/scripts/scan-allowlist.txt
+++ b/scripts/scan-allowlist.txt
@@ -54,6 +54,16 @@ plugins/community/skills-janitor/scripts/search.sh:secret-exfil-cooccur  GITHUB_
 plugins/community/skills-janitor/scripts/precheck.sh:secret-exfil-cooccur  GITHUB_TOKEN attached only to the api.github.com request (AUTH_ARGS array), never to the raw or arbitrary-URL fetches
 plugins/community/skills-janitor/scripts/compare.sh:secret-exfil-cooccur  GITHUB_TOKEN sent only as an Authorization header to api.github.com, its own service
 
+# ── governed-second-brain committed runtime bundle — reviewed 2026-07-16 @ upstream 967fb70f. ──
+# The team-mode client sends TEAMKB_API_TOKEN only to the owner-configured
+# TEAMKB_API_URL; local mode is in-process and performs no runtime network after
+# its one-time pinned native dependency install. The dynamic constructor is
+# AJV's bundled schema compiler operating on the plugin's fixed schemas, not
+# user-provided source text. The upstream clean-install and full-chain smokes
+# exercise both modes, fail-closed dispatch, governance, and audit verification.
+plugins/mcp/governed-second-brain/plugin-runtime/governed-brain.cjs:secret-exfil-cooccur  team-mode TEAMKB_API_TOKEN is sent only to its configured TEAMKB_API_URL service; reviewed upstream bundle 967fb70f
+plugins/mcp/governed-second-brain/plugin-runtime/governed-brain.cjs:dynamic-exec  AJV schema compiler in the generated bundle compiles fixed plugin schemas, not user-provided source text; reviewed upstream bundle 967fb70f
+
 # ── sources-change-unscanned is a ONE-SHOT waiver (enforced in code by
 # honoredWaivers, blocker 62ye.3 / #985 defect 3): a line is honored ONLY in the
 # PR whose diff adds it, so it can never persistently waive future source-list

--- a/sources.lock.json
+++ b/sources.lock.json
@@ -301,19 +301,20 @@
     },
     "governed-second-brain": {
       "repo": "jeremylongshore/governed-second-brain-plugin",
-      "resolved_ref": "1f3c0681d233d1c71f6863cd864fb9386df1d7a5",
-      "locked_at": "2026-07-13T17:26:52.936Z",
+      "resolved_ref": "40266d1b8fb5877ff504f2554821a96d685390be",
+      "locked_at": "2026-07-16T06:12:34.954Z",
       "files": {
-        ".claude-plugin/marketplace.json": "sha256:f28f69667d61ed92219d30bb1b3784ed989e2ca05895f6b94bf1b9cf4a058e12",
-        ".claude-plugin/plugin.json": "sha256:2a0c4b97911450479ec8d01e7096780e6625761856cb4dc04ebe9ba0ecf89926",
-        ".mcp.json": "sha256:b5dbf969a86e74af228fa6feb2c14da97f72f2156481f1c77625e7491ef3eb7b",
+        ".claude-plugin/marketplace.json": "sha256:c260d0aaab5c1cd8687abdd19403d5f6c7964bab4d780455c85d206ba351cda8",
+        ".claude-plugin/plugin.json": "sha256:efae12f80b1a46c2f5bb26eb6b98aa3e4be4b03c8dfdbb68f54a36b32b4864d2",
+        ".mcp.json": "sha256:70cd02b7ac203d91e07cc710acc5d1d8d5ce987751392c57dde58ab4b7da5276",
         "LICENSE": "sha256:393f9b0a3ffff1e35d5243049719ec982d0663713542fd417b64a7df4c04a361",
-        "README.md": "sha256:9f3f811640aa2cab3f9f1a98e8b904a7a8ff6562897f5fcede250232f321ca3a",
-        "plugin-runtime/governed-brain.cjs": "sha256:2fac90532ecda9bc0d669bb85b4918a10acc0efccd80777b28aca32e9ec0e1a8",
-        "plugin-runtime/package-lock.json": "sha256:807be9daedf14036e1bbacf42028108318d859037ffb11a4c72e6359b0672534",
-        "plugin-runtime/package.json": "sha256:e20ddace610f417fdf8419651eecfcbaa3d0d1dbff24f2b05ce8f3ae2c505827",
-        "skills/brain-save/SKILL.md": "sha256:a87a84d6da25ca890f6c885d02b029312a3a50a7ec4fc9ec6d9ff3e502fef6f7",
-        "skills/brain/SKILL.md": "sha256:d74bcd8559c4281b9729446ba553be84f88da38588d9f166157ce94deb27ee3f"
+        "README.md": "sha256:d0b12754b24bd0f5f54a0878e2697ae329c1a669ef9850b9f4d34ca60bfa1d57",
+        "plugin-runtime/bootstrap.cjs": "sha256:80c8e9021685ce717aa063e180ba671050f8ee49d5ff5e550963154b9bdd700b",
+        "plugin-runtime/governed-brain.cjs": "sha256:ee4b0eb333fca56b8f8651b18f86b3cf7bc5811053abfa27eee142e1c4dd0b8e",
+        "plugin-runtime/package-lock.json": "sha256:f692d0e4060eae895cf8fd23f2d766060f390a45185b14dfb2f7796fad9ef7d2",
+        "plugin-runtime/package.json": "sha256:00e46e6950f0641bfbee431e017a2f6a5aac07eef8f3ab716867e97bad5e4a46",
+        "skills/brain-save/SKILL.md": "sha256:ddf3bd966ecac662edb092dfb313795cd1f8704fa9ca8c93adae05ed790cc49a",
+        "skills/brain/SKILL.md": "sha256:41f356fee964c49ee4cf476e43260c07423a387a781b5fbc2641104ecb96b874"
       }
     },
     "hermes-tweet": {

--- a/sources.lock.json
+++ b/sources.lock.json
@@ -301,14 +301,14 @@
     },
     "governed-second-brain": {
       "repo": "jeremylongshore/bobs-big-brain-plugin",
-      "resolved_ref": "967fb70f8a010508c427869148d96ecb6079dbaf",
-      "locked_at": "2026-07-16T06:30:06.388Z",
+      "resolved_ref": "021b746e4794d73b175e4fc5e3d7dcb5f4ff9f54",
+      "locked_at": "2026-07-16T06:44:55.551Z",
       "files": {
         ".claude-plugin/marketplace.json": "sha256:c260d0aaab5c1cd8687abdd19403d5f6c7964bab4d780455c85d206ba351cda8",
         ".claude-plugin/plugin.json": "sha256:efae12f80b1a46c2f5bb26eb6b98aa3e4be4b03c8dfdbb68f54a36b32b4864d2",
         ".mcp.json": "sha256:0a14e10aa5b76c52c3453057195f7dea3386a9f430e2f3cc936e52e68fb8d3a3",
         "LICENSE": "sha256:393f9b0a3ffff1e35d5243049719ec982d0663713542fd417b64a7df4c04a361",
-        "README.md": "sha256:d0b12754b24bd0f5f54a0878e2697ae329c1a669ef9850b9f4d34ca60bfa1d57",
+        "README.md": "sha256:4b904fbdb641e2c060f893bd36fbab7fdb0d2e8197823eedbf23f267e264f731",
         "plugin-runtime/bootstrap.cjs": "sha256:80c8e9021685ce717aa063e180ba671050f8ee49d5ff5e550963154b9bdd700b",
         "plugin-runtime/governed-brain.cjs": "sha256:ee4b0eb333fca56b8f8651b18f86b3cf7bc5811053abfa27eee142e1c4dd0b8e",
         "plugin-runtime/package-lock.json": "sha256:f692d0e4060eae895cf8fd23f2d766060f390a45185b14dfb2f7796fad9ef7d2",

--- a/sources.lock.json
+++ b/sources.lock.json
@@ -300,13 +300,13 @@
       }
     },
     "governed-second-brain": {
-      "repo": "jeremylongshore/governed-second-brain-plugin",
-      "resolved_ref": "40266d1b8fb5877ff504f2554821a96d685390be",
-      "locked_at": "2026-07-16T06:12:34.954Z",
+      "repo": "jeremylongshore/bobs-big-brain-plugin",
+      "resolved_ref": "967fb70f8a010508c427869148d96ecb6079dbaf",
+      "locked_at": "2026-07-16T06:30:06.388Z",
       "files": {
         ".claude-plugin/marketplace.json": "sha256:c260d0aaab5c1cd8687abdd19403d5f6c7964bab4d780455c85d206ba351cda8",
         ".claude-plugin/plugin.json": "sha256:efae12f80b1a46c2f5bb26eb6b98aa3e4be4b03c8dfdbb68f54a36b32b4864d2",
-        ".mcp.json": "sha256:70cd02b7ac203d91e07cc710acc5d1d8d5ce987751392c57dde58ab4b7da5276",
+        ".mcp.json": "sha256:0a14e10aa5b76c52c3453057195f7dea3386a9f430e2f3cc936e52e68fb8d3a3",
         "LICENSE": "sha256:393f9b0a3ffff1e35d5243049719ec982d0663713542fd417b64a7df4c04a361",
         "README.md": "sha256:d0b12754b24bd0f5f54a0878e2697ae329c1a669ef9850b9f4d34ca60bfa1d57",
         "plugin-runtime/bootstrap.cjs": "sha256:80c8e9021685ce717aa063e180ba671050f8ee49d5ff5e550963154b9bdd700b",

--- a/sources.yaml
+++ b/sources.yaml
@@ -760,12 +760,12 @@ sources:
 
   # ============================================================
   # Governed Second Brain (Jeremy Longshore / Intent Solutions)
-  # https://github.com/jeremylongshore/governed-second-brain-plugin
+  # https://github.com/jeremylongshore/bobs-big-brain-plugin
   # ============================================================
 
   - name: governed-second-brain
     description: Local-first governed second brain — turn your files into cited (qmd://) memory with deterministic governance and a tamper-evident, hash-chained audit trail. Install via `npx governed-second-brain init <folder>`.
-    repo: jeremylongshore/governed-second-brain-plugin
+    repo: jeremylongshore/bobs-big-brain-plugin
     source_path: .
     target_path: plugins/mcp/governed-second-brain
     author:


### PR DESCRIPTION
Mirrors bobs-big-brain-plugin v1.1.2 after upstream PRs #43 and #44. Includes the lockfile-pinned bootstrap and native runtime lockfile, updates the external source to the canonical repository, refreshes catalog metadata, and preserves source-lock hashes. Upstream required CI now proves a clean copied plugin can start both modes and complete local capture, governance, status, and audit without polluting a real brain. Tracking bead: claude-zqt9.