### PR TITLE
fix(markdown): restore baseline lint

### DIFF
--- a/marketplace/src/content/blog-posts/exit-0-is-not-success.md
+++ b/marketplace/src/content/blog-posts/exit-0-is-not-success.md
@@ -98,4 +98,3 @@ Exit 0 means the process finished. Outcome verification means the work finished.
 - [Empty Is Not Clean: Five Fail-Open Bugs in an AI Agent](/posts/empty-is-not-clean/)
 - [Liveness Without Health Is Theater](/posts/liveness-without-health-is-theater/)
 - [Every Safety Gate Has a Failure Direction](/posts/every-safety-gate-has-a-failure-direction/)
-

--- a/marketplace/src/content/blog-posts/producer-fallback-when-claude-hits-weekly-limit.md
+++ b/marketplace/src/content/blog-posts/producer-fallback-when-claude-hits-weekly-limit.md
@@ -86,4 +86,3 @@ Tomorrow's 04:00 run can try Claude, fall back to Grok, and still land. That is 
 - [Exit 0 Is Not Success: Automation Assurance That Verifies Outcomes](/posts/exit-0-is-not-success/)
 - [Liveness Without Health Is Theater](/posts/liveness-without-health-is-theater/)
 - [Empty Is Not Clean: Five Fail-Open Bugs in an AI Agent](/posts/empty-is-not-clean/)
-


### PR DESCRIPTION
Removes one extra trailing blank line from each of the two newest marketplace blog posts. markdownlint-cli2 0.22.1 reports zero errors afterward. This is a narrow prerequisite fix for the current main-branch validation baseline.