### PR TITLE
docs(ops): point VPS authority to Intent OS

### DIFF
--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -4,7 +4,7 @@ name: Deploy tonsofskills.com to VPS
 # rsync marketplace/dist → /srv/tonsofskills/dist → smoke check passes.
 #
 # Replaces deploy-firebase.yml (disabled). See VPS-as-the-home Priority 7 Stage B
-# and intentsolutions-vps-runbook/docs/onboard-new-repo-deploy.md.
+# and intent-solutions-io/intent-os/ops/deploy (D90).
 
 on:
   push:

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -29,7 +29,7 @@ This repo is the **Tons of Skills** marketplace for Claude Code plugins and skil
 
 ## Related repos (multi-repo context)
 
-This repo depends on **`@intentsolutions/core`** (the authoring-schema kernel SSoT — a separate package/repo) and deploys to tonsofskills.com via the **intentsolutions-vps-runbook** repo. Greptile's current config schema does not expose a multi-repo `patternRepositories` key, so these are noted here for reviewer context rather than wired into `config.json`.
+This repo depends on **`@intentsolutions/core`** (the authoring-schema kernel SSoT — a separate package/repo) and follows the deployment authority in **`intent-solutions-io/intent-os/ops/deploy`**. Greptile's current config schema does not expose a multi-repo `patternRepositories` key, so these are noted here for reviewer context rather than wired into `config.json`.
 
 ## Reviewing a `sources.yaml` entry
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ Performance budgets (CI-enforced): 40 MB total gzipped, 1 MB largest file, < 30s
 2. `cowork:validate` (`scripts/validate-cowork-manifest.mjs`) — drift gate. Fails the build if catalog ↔ manifest ↔ disk fall out of alignment (orphan zips, missing entries, or stale manifest rows). Runs again in CI as a discrete step in `.github/workflows/validate-plugins.yml` so the failure signal is clearly named.
 3. `astro build` — copies `marketplace/public/` → `marketplace/dist/`. The `/cowork/` page reads `cowork-manifest.json` at build time and renders the download grid.
 
-**Deploy propagates the wipe.** The VPS force-command script `/usr/local/sbin/deploy-tonsofskills` ends with `rsync -a --delete /srv/tonsofskills/build/marketplace/dist/ /srv/tonsofskills/dist/`, so orphan files removed by the cowork build are also pruned from the served `dist/`. Documented in `intentsolutions-vps-runbook/docs/onboard-new-repo-deploy.md` § "Atomic deploy convention".
+**Deploy propagates the wipe.** The VPS force-command script `/usr/local/sbin/deploy-tonsofskills` ends with `rsync -a --delete /srv/tonsofskills/build/marketplace/dist/ /srv/tonsofskills/dist/`, so orphan files removed by the cowork build are also pruned from the served `dist/`. Current deployment authority is `intent-os/ops/deploy/`.
 
 **Don't commit downloads/.** `marketplace/public/downloads/` is gitignored (see `.gitignore:146`). CI checks out fresh and rebuilds from scratch — local state cannot leak to prod. Never commit or hand-edit anything under that directory.
 

--- a/marketplace/src/content/blog-posts/copying-files-is-not-installing.md
+++ b/marketplace/src/content/blog-posts/copying-files-is-not-installing.md
@@ -159,4 +159,3 @@ If you ship a plugin with native dependencies to any marketplace that installs b
 Two hygiene fixes rode along in the same release, both small, both the difference between an install that reads clean to a new user and one that does not. The MCP manifest's `description` had command-shaped text in it, so it got rewritten as plain prose. A description is metadata a human reads, not a script, and shell syntax in a schema field is just noise that trips linters and confuses readers. And a team-onboarding README example pointed at an invalid API URL, corrected to a valid local example, so the first thing a new team user copies actually works.
 
 This shipped as v1.1.2. The one-line version: copying files is not installing, and a plugin that assumes otherwise works only on the machine where the files were already installed.
-

--- a/marketplace/src/layouts/BaseLayout.astro
+++ b/marketplace/src/layouts/BaseLayout.astro
@@ -689,7 +689,7 @@ const currentPath = Astro.url.pathname;
          that forwards to the Slack webhook in /etc/intentsolutions/notify.env.
          Anti-spam: honeypot field `website`, email/URL regex, 8 KiB body cap,
          per-IP rate limit on the server. See
-         intentsolutions-vps-runbook/docs/tonsofskills-forms-api.md. -->
+         intent-os/ops/host/services/forms-api. -->
     <script type="module" is:inline>
       (() => {
         const flash = (btn, msg, ok = true, restoreMs = 3000) => {

--- a/marketplace/tests/production/P3-redirects.spec.ts
+++ b/marketplace/tests/production/P3-redirects.spec.ts
@@ -30,7 +30,7 @@ test.describe('P3: Domain Redirects', () => {
     // Caddy preserves URI: claudecoworkskills.io/<path> -> tonsofskills.com/<path>.
     // Bare-domain hits land on the homepage, not /cowork — that's product behavior,
     // not a bug. If we ever want vanity-domain → /cowork landing, it goes in the
-    // Caddyfile redir rule (intentsolutions-vps-runbook), not in this test.
+    // Caddyfile redirect rule (intent-os/ops/ingress), not in this test.
     const response = await request.get('https://claudecoworkskills.io', {
       maxRedirects: 0,
       failOnStatusCode: false,


### PR DESCRIPTION
Cuts active workflow and operator references over to the D90 Intent OS authority. Historical evidence references are preserved. No runtime, credential, schedule, or deployment behavior changes.