### PR TITLE
feat(governance): add @blueandyellow44 as top-tier co-maintainer (all areas)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,14 +21,14 @@
 # ---------------------------------------------------------------------------
 # Default: the Lead owns everything not explicitly delegated below.
 # ---------------------------------------------------------------------------
-*                                   @jeremylongshore
+*                                   @jeremylongshore @blueandyellow44
 
 # ---------------------------------------------------------------------------
 # area: ci-infra  — HIGH TRUST. A workflow edit can bypass every validator gate.
 # Lead-owned until an Approver has passed the pipeline quiz (GOVERNANCE § Vetting).
 # ---------------------------------------------------------------------------
-/.github/                           @jeremylongshore
-/.github/workflows/                 @jeremylongshore
+/.github/                           @jeremylongshore @blueandyellow44
+/.github/workflows/                 @jeremylongshore @blueandyellow44
 # After @opeyemiariyo-netizen passes the pipeline quiz (000-docs/705), uncomment to make their review
 # satisfy the code-owner gate on CI/deploy — the Reviewer → Approver promotion:
 # /.github/workflows/               @jeremylongshore @opeyemiariyo-netizen
@@ -38,34 +38,34 @@
 # area: validator-schema  — HIGH TRUST. The quality bar itself. Changes are
 # approval-gated per 000-docs/SCHEMA_CHANGELOG.md NON-NEGOTIABLES. Lead-owned.
 # ---------------------------------------------------------------------------
-/scripts/validate-skills-schema.py  @jeremylongshore
-/scripts/validate-unicode-hygiene.py  @jeremylongshore
-/scripts/run-verification-pipeline.mjs  @jeremylongshore
-/scripts/check-package-manager.mjs  @jeremylongshore
-/scripts/kernel-shadow-validation.mjs  @jeremylongshore
-/scripts/kernel-vendor-hash.mjs     @jeremylongshore
-/000-docs/SCHEMA_CHANGELOG.md       @jeremylongshore
+/scripts/validate-skills-schema.py  @jeremylongshore @blueandyellow44
+/scripts/validate-unicode-hygiene.py  @jeremylongshore @blueandyellow44
+/scripts/run-verification-pipeline.mjs  @jeremylongshore @blueandyellow44
+/scripts/check-package-manager.mjs  @jeremylongshore @blueandyellow44
+/scripts/kernel-shadow-validation.mjs  @jeremylongshore @blueandyellow44
+/scripts/kernel-vendor-hash.mjs     @jeremylongshore @blueandyellow44
+/000-docs/SCHEMA_CHANGELOG.md       @jeremylongshore @blueandyellow44
 
 # ---------------------------------------------------------------------------
 # area: deps  — HIGH TRUST. A single bad upgrade is a supply-chain incident.
 # ---------------------------------------------------------------------------
-/package.json                       @jeremylongshore
-/pnpm-lock.yaml                     @jeremylongshore
-/pnpm-workspace.yaml                @jeremylongshore
+/package.json                       @jeremylongshore @blueandyellow44
+/pnpm-lock.yaml                     @jeremylongshore @blueandyellow44
+/pnpm-workspace.yaml                @jeremylongshore @blueandyellow44
 
 # ---------------------------------------------------------------------------
 # area: external-sync  — supply-chain-sensitive mirror pipeline.
 # ---------------------------------------------------------------------------
-/sources.yaml                       @jeremylongshore
-/sources.lock.json                  @jeremylongshore
-/scripts/sync-external.mjs          @jeremylongshore
-/scripts/scan-synced-content.mjs    @jeremylongshore
-/scripts/scan-allowlist.txt         @jeremylongshore
+/sources.yaml                       @jeremylongshore @blueandyellow44
+/sources.lock.json                  @jeremylongshore @blueandyellow44
+/scripts/sync-external.mjs          @jeremylongshore @blueandyellow44
+/scripts/scan-synced-content.mjs    @jeremylongshore @blueandyellow44
+/scripts/scan-allowlist.txt         @jeremylongshore @blueandyellow44
 
 # ---------------------------------------------------------------------------
 # area: marketplace-site  — the Astro site, design system, build pipeline.
 # ---------------------------------------------------------------------------
-/marketplace/                       @jeremylongshore
+/marketplace/                       @jeremylongshore @blueandyellow44
 # After @opeyemiariyo-netizen passes the pipeline quiz (000-docs/705), uncomment to make their review
 # satisfy the code-owner gate on the site — the Reviewer → Approver promotion:
 # /marketplace/                     @jeremylongshore @opeyemiariyo-netizen
@@ -73,29 +73,29 @@
 # ---------------------------------------------------------------------------
 # area: freshie  — the inventory CMDB, Dolt sync, grading.
 # ---------------------------------------------------------------------------
-/freshie/                           @jeremylongshore
+/freshie/                           @jeremylongshore @blueandyellow44
 
 # ---------------------------------------------------------------------------
 # area: docs-governance  — contributor-facing standards and the ladder itself.
 # ---------------------------------------------------------------------------
-/000-docs/                          @jeremylongshore
-/GOVERNANCE.md                      @jeremylongshore
-/MAINTAINERS.md                     @jeremylongshore
-/CONTRIBUTING.md                    @jeremylongshore
-/.github/CONTRIBUTING.md            @jeremylongshore
-/SECURITY.md                        @jeremylongshore
-/CODE_OF_CONDUCT.md                 @jeremylongshore
+/000-docs/                          @jeremylongshore @blueandyellow44
+/GOVERNANCE.md                      @jeremylongshore @blueandyellow44
+/MAINTAINERS.md                     @jeremylongshore @blueandyellow44
+/CONTRIBUTING.md                    @jeremylongshore @blueandyellow44
+/.github/CONTRIBUTING.md            @jeremylongshore @blueandyellow44
+/SECURITY.md                        @jeremylongshore @blueandyellow44
+/CODE_OF_CONDUCT.md                 @jeremylongshore @blueandyellow44
 
 # ---------------------------------------------------------------------------
 # area: catalog + root policy  — source-of-truth catalog and repo policy.
 # ---------------------------------------------------------------------------
-/.claude-plugin/                    @jeremylongshore
-/.gemini/                           @jeremylongshore
-/.greptile/                         @jeremylongshore
-/CLAUDE.md                          @jeremylongshore
-/AGENTS.md                          @jeremylongshore
-/LICENSE                            @jeremylongshore
-/LICENSE-TEMPLATE-PROPRIETARY.txt   @jeremylongshore
+/.claude-plugin/                    @jeremylongshore @blueandyellow44
+/.gemini/                           @jeremylongshore @blueandyellow44
+/.greptile/                         @jeremylongshore @blueandyellow44
+/CLAUDE.md                          @jeremylongshore @blueandyellow44
+/AGENTS.md                          @jeremylongshore @blueandyellow44
+/LICENSE                            @jeremylongshore @blueandyellow44
+/LICENSE-TEMPLATE-PROPRIETARY.txt   @jeremylongshore @blueandyellow44
 
 # ---------------------------------------------------------------------------
 # Per-plugin owners (Home-Assistant style). AUTO-GENERATED — do not hand-edit

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -20,6 +20,7 @@ quality signal but does not yet satisfy that gate.
 | Handle                                                           | Tier                                                                                                                                 | Area(s)                        | Backup           | Notes                                                                                                                     |
 | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------ | ---------------- | ------------------------------------------------------------------------------------------------------------------------- |
 | [@jeremylongshore](https://github.com/jeremylongshore)           | **Lead**                                                                                                                             | all                            | —                | Owns the repo, releases, and all high-trust paths (validators, schema, CI, deps, root policy).                            |
+| [@blueandyellow44](https://github.com/blueandyellow44)           | **Maintainer**                                                                                                                       | all                            | @jeremylongshore | Co-maintainer at the top tier — code-owner on every area (paired with the Lead), sets direction, can sponsor others up.   |
 | [@opeyemiariyo-netizen](https://github.com/opeyemiariyo-netizen) | **Reviewer** → Approver on `ci-infra` + `marketplace-site` once the [pipeline quiz](000-docs/705-DR-GUID-pipeline-quiz.md) is passed | `ci-infra`, `marketplace-site` | @jeremylongshore | Promotion to Approver is gated on the pipeline quiz — see [GOVERNANCE § Vetting](GOVERNANCE.md#vetting--how-you-move-up). |
 
 ### Invitation pending
@@ -49,6 +50,7 @@ Editorial pick, rotated so it is not always the Lead. The picker for the week ru
 | Rotation slot      | Picker           |
 | ------------------ | ---------------- |
 | Default / fallback | @jeremylongshore |
+| Rotation           | @blueandyellow44 |
 
 _(Rotation expands as Reviewers/Approvers are added — add a row per picker.)_
 


### PR DESCRIPTION
## What

Seats **@blueandyellow44** at the maximum tier of the maintainer ladder — **Maintainer, all areas** — pairing them with the Lead as a code-owner on every path.

- `MAINTAINERS.md` — new roster row (Maintainer / all areas / backup Lead) + a skill-of-the-week rotation slot.
- `.github/CODEOWNERS` — added `@blueandyellow44` alongside `@jeremylongshore` on all 34 hand-authored area lines (default + every per-area block, incl. the high-trust CI/validator/deps/policy paths), so their review satisfies the code-owner merge gate everywhere. **Active immediately** — no quiz gate (unlike the Reviewer seat).

## Why

Lead directive to add them at max trust. A Maintainer/all-areas seat is the top working tier (GOVERNANCE.md), which directly reduces the single-approver bottleneck the ladder exists to fix.

## Operational

- Repo collaborator invite sent at `admin` (personal repos only offer pull/push/admin — the `maintain` role needs the org; another Track D driver). **Invite pending acceptance** — code-owner review routing activates once accepted; until then GitHub's CODEOWNERS check may list them as not-yet-a-collaborator (not a merge-blocking `ci-required` gate).
- Left the AUTO-GENERATED per-plugin block untouched (driven by the `maintainer` catalog field; hand-editing it would trip `codeowners-drift`).

## Verification

- `node scripts/generate-codeowners.mjs --check` green; `pnpm format:check` green; 34 area lines updated, generated + commented example lines untouched.

- Jeremy Longshore
intentsolutions.io