### PR TITLE
feat(governance): promote @opeyemiariyo-netizen to Approver (ci-infra + marketplace-site)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,14 +25,12 @@
 
 # ---------------------------------------------------------------------------
 # area: ci-infra  — HIGH TRUST. A workflow edit can bypass every validator gate.
-# Lead-owned until an Approver has passed the pipeline quiz (GOVERNANCE § Vetting).
+# @opeyemiariyo-netizen is an Approver here (Lead promotion 2026-07-16 — see GOVERNANCE
+# § Vetting; the pipeline quiz was waived in favor of learn-on-the-job mentoring).
 # ---------------------------------------------------------------------------
 /.github/                           @jeremylongshore @blueandyellow44
-/.github/workflows/                 @jeremylongshore @blueandyellow44
-# After @opeyemiariyo-netizen passes the pipeline quiz (000-docs/705), uncomment to make their review
-# satisfy the code-owner gate on CI/deploy — the Reviewer → Approver promotion:
-# /.github/workflows/               @jeremylongshore @opeyemiariyo-netizen
-# /.github/workflows/deploy-vps.yml @jeremylongshore @opeyemiariyo-netizen
+/.github/workflows/                 @jeremylongshore @blueandyellow44 @opeyemiariyo-netizen
+/.github/workflows/deploy-vps.yml   @jeremylongshore @blueandyellow44 @opeyemiariyo-netizen
 
 # ---------------------------------------------------------------------------
 # area: validator-schema  — HIGH TRUST. The quality bar itself. Changes are
@@ -64,11 +62,9 @@
 
 # ---------------------------------------------------------------------------
 # area: marketplace-site  — the Astro site, design system, build pipeline.
+# @opeyemiariyo-netizen is an Approver here (Lead promotion 2026-07-16).
 # ---------------------------------------------------------------------------
-/marketplace/                       @jeremylongshore @blueandyellow44
-# After @opeyemiariyo-netizen passes the pipeline quiz (000-docs/705), uncomment to make their review
-# satisfy the code-owner gate on the site — the Reviewer → Approver promotion:
-# /marketplace/                     @jeremylongshore @opeyemiariyo-netizen
+/marketplace/                       @jeremylongshore @blueandyellow44 @opeyemiariyo-netizen
 
 # ---------------------------------------------------------------------------
 # area: freshie  — the inventory CMDB, Dolt sync, grading.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -17,11 +17,11 @@ quality signal but does not yet satisfy that gate.
 
 ## Roster
 
-| Handle                                                           | Tier                                                                                                                                 | Area(s)                        | Backup           | Notes                                                                                                                     |
-| ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------ | ---------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| [@jeremylongshore](https://github.com/jeremylongshore)           | **Lead**                                                                                                                             | all                            | —                | Owns the repo, releases, and all high-trust paths (validators, schema, CI, deps, root policy).                            |
-| [@blueandyellow44](https://github.com/blueandyellow44)           | **Maintainer**                                                                                                                       | all                            | @jeremylongshore | Co-maintainer at the top tier — code-owner on every area (paired with the Lead), sets direction, can sponsor others up.   |
-| [@opeyemiariyo-netizen](https://github.com/opeyemiariyo-netizen) | **Reviewer** → Approver on `ci-infra` + `marketplace-site` once the [pipeline quiz](000-docs/705-DR-GUID-pipeline-quiz.md) is passed | `ci-infra`, `marketplace-site` | @jeremylongshore | Promotion to Approver is gated on the pipeline quiz — see [GOVERNANCE § Vetting](GOVERNANCE.md#vetting--how-you-move-up). |
+| Handle                                                           | Tier           | Area(s)                        | Backup           | Notes                                                                                                                                  |
+| ---------------------------------------------------------------- | -------------- | ------------------------------ | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| [@jeremylongshore](https://github.com/jeremylongshore)           | **Lead**       | all                            | —                | Owns the repo, releases, and all high-trust paths (validators, schema, CI, deps, root policy).                                         |
+| [@blueandyellow44](https://github.com/blueandyellow44)           | **Maintainer** | all                            | @jeremylongshore | Co-maintainer at the top tier — code-owner on every area (paired with the Lead), sets direction, can sponsor others up.                |
+| [@opeyemiariyo-netizen](https://github.com/opeyemiariyo-netizen) | **Approver**   | `ci-infra`, `marketplace-site` | @jeremylongshore | Code-owner on CI/deploy + the marketplace site. Promoted by the Lead 2026-07-16 (pipeline quiz waived for learn-on-the-job mentoring). |
 
 ### Invitation pending
 


### PR DESCRIPTION
## What

Promotes **@opeyemiariyo-netizen** from Reviewer to **Approver** on `ci-infra` and `marketplace-site`.

- `.github/CODEOWNERS` — added them alongside `@jeremylongshore` + `@blueandyellow44` on `/.github/workflows/`, `/.github/workflows/deploy-vps.yml`, and `/marketplace/`, so their approving review now satisfies the code-owner merge gate on those areas. Removed the obsolete "after the quiz, uncomment" example blocks.
- `MAINTAINERS.md` — Ope's row updated Reviewer → Approver.

## Why (+ decision rationale)

Lead decision to promote now and **waive the pipeline quiz** in favor of learn-on-the-job mentoring. Chose to fold Ope into the existing multi-owner lines (three owners) rather than uncomment the pre-written single-owner example — the example predated `@blueandyellow44`'s addition and a literal uncomment would have **dropped them** from those paths.

## Verification

- `@opeyemiariyo-netizen` is already an admin collaborator (write access), so CODEOWNERS resolves with **no "unknown owner"**.
- `node scripts/generate-codeowners.mjs --check` green (per-plugin block untouched); `pnpm format:check` green.

## Risk / operational

No runtime change — ownership routing only. Branch-protection required set unchanged (`ci-required` + `gitleaks`).

- Jeremy Longshore
intentsolutions.io