### PR TITLE
fix(catalog): repair SKILL.md drift + 3 downgrades, make --check verify all surfaces [skip auto-bump]

### DIFF
--- a/.claude-plugin/marketplace.extended.json
+++ b/.claude-plugin/marketplace.extended.json
@@ -977,7 +977,7 @@
       "name": "browser-compatibility-tester",
       "source": "./plugins/testing/browser-compatibility-tester",
       "description": "Cross-browser testing with BrowserStack, Selenium Grid, and Playwright - test across Chrome, Firefox, Safari, Edge",
-      "version": "1.20.0",
+      "version": "2.20.0",
       "category": "testing",
       "keywords": [
         "testing",
@@ -2536,7 +2536,7 @@
       "name": "formatter",
       "source": "./plugins/examples/formatter",
       "description": "Code formatting plugin using hooks to auto-format on save",
-      "version": "1.26.0",
+      "version": "2.26.0",
       "category": "examples",
       "keywords": ["formatting", "hooks", "automation"],
       "verification": {
@@ -5397,7 +5397,7 @@
       "name": "claude-never-forgets",
       "source": "./plugins/community/claude-never-forgets",
       "description": "Persistent memory plugin for Claude Code - remembers preferences, decisions, and corrections across sessions and context limits",
-      "version": "0.21.0",
+      "version": "1.21.0",
       "category": "community",
       "keywords": ["memory", "context", "persistent", "preferences", "sessions", "recall"],
       "author": {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -879,7 +879,7 @@
       "name": "browser-compatibility-tester",
       "source": "./plugins/testing/browser-compatibility-tester",
       "description": "Cross-browser testing with BrowserStack, Selenium Grid, and Playwright - test across Chrome, Firefox, Safari, Edge",
-      "version": "1.20.0",
+      "version": "2.20.0",
       "category": "testing",
       "keywords": [
         "testing",
@@ -2334,7 +2334,7 @@
       "name": "formatter",
       "source": "./plugins/examples/formatter",
       "description": "Code formatting plugin using hooks to auto-format on save",
-      "version": "1.26.0",
+      "version": "2.26.0",
       "category": "examples",
       "keywords": [
         "formatting",
@@ -4977,7 +4977,7 @@
       "name": "claude-never-forgets",
       "source": "./plugins/community/claude-never-forgets",
       "description": "Persistent memory plugin for Claude Code - remembers preferences, decisions, and corrections across sessions and context limits",
-      "version": "0.21.0",
+      "version": "1.21.0",
       "category": "community",
       "keywords": [
         "memory",

--- a/plugins/community/claude-never-forgets/.claude-plugin/plugin.json
+++ b/plugins/community/claude-never-forgets/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-never-forgets",
-  "version": "0.21.0",
+  "version": "1.21.0",
   "description": "Persistent memory across sessions. Learns preferences, conventions, and corrections automatically.",
   "author": {
     "name": "yldrmahmet",

--- a/plugins/community/claude-never-forgets/skills/memory/SKILL.md
+++ b/plugins/community/claude-never-forgets/skills/memory/SKILL.md
@@ -11,7 +11,7 @@ description: 'Execute extract and use project memories from previous sessions fo
 
   '
 allowed-tools: Read, Write
-version: 0.21.0
+version: 1.21.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
 tags:

--- a/plugins/examples/formatter/.claude-plugin/plugin.json
+++ b/plugins/examples/formatter/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "formatter",
-  "version": "1.26.0",
+  "version": "2.26.0",
   "description": "Comprehensive code formatting plugin with Prettier integration. Use when you need to format code, validate formatting, or maintain consistent code style. Activates with phrases like 'format my code', 'check formatting', or 'apply code style'. Supports JavaScript, TypeScript, JSON, CSS, Markdown, and many other file types with automatic formatting on file operations.",
   "author": {
     "name": "Jeremy Longshore",

--- a/plugins/examples/formatter/skills/code-formatter/SKILL.md
+++ b/plugins/examples/formatter/skills/code-formatter/SKILL.md
@@ -12,7 +12,7 @@ description: 'Execute automatically formats and validates code files using Prett
 
   '
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(cmd:*)
-version: 1.26.0
+version: 2.26.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
 tags:

--- a/plugins/saas-packs/clerk-pack/skills/clerk-ci-integration/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-ci-integration/SKILL.md
@@ -12,7 +12,7 @@ description: 'Configure Clerk CI/CD integration with GitHub Actions and testing.
 
   '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/plugins/saas-packs/clerk-pack/skills/clerk-common-errors/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-common-errors/SKILL.md
@@ -12,7 +12,7 @@ description: 'Troubleshoot common Clerk errors and issues.
 
   '
 allowed-tools: Read, Write, Edit, Grep, Bash(npm:*)
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/plugins/saas-packs/clerk-pack/skills/clerk-core-workflow-a/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-core-workflow-a/SKILL.md
@@ -12,7 +12,7 @@ description: 'Implement user sign-up and sign-in flows with Clerk.
 
   '
 allowed-tools: Read, Write, Edit, Grep
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/plugins/saas-packs/clerk-pack/skills/clerk-core-workflow-b/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-core-workflow-b/SKILL.md
@@ -12,7 +12,7 @@ description: 'Implement session management and middleware with Clerk.
 
   '
 allowed-tools: Read, Write, Edit, Grep
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/plugins/saas-packs/clerk-pack/skills/clerk-data-handling/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-data-handling/SKILL.md
@@ -12,7 +12,7 @@ description: 'Handle user data, privacy, and GDPR compliance with Clerk.
 
   '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/plugins/saas-packs/clerk-pack/skills/clerk-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-debug-bundle/SKILL.md
@@ -12,7 +12,7 @@ description: 'Collect comprehensive debug information for Clerk issues.
 
   '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*), Grep
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/plugins/saas-packs/clerk-pack/skills/clerk-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-deploy-integration/SKILL.md
@@ -12,7 +12,7 @@ description: 'Configure Clerk for deployment on various platforms.
 
   '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(netlify:*), Grep
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/plugins/saas-packs/clerk-pack/skills/clerk-enterprise-rbac/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-enterprise-rbac/SKILL.md
@@ -13,7 +13,7 @@ description: 'Configure enterprise SSO, role-based access control, and organizat
 
   '
 allowed-tools: Read, Write, Edit, Grep
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/plugins/saas-packs/clerk-pack/skills/clerk-hello-world/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-hello-world/SKILL.md
@@ -12,7 +12,7 @@ description: 'Create your first authenticated request with Clerk.
 
   '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/plugins/saas-packs/clerk-pack/skills/clerk-incident-runbook/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-incident-runbook/SKILL.md
@@ -12,7 +12,7 @@ description: 'Manage incident response for Clerk authentication issues.
 
   '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/plugins/saas-packs/clerk-pack/skills/clerk-install-auth/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-install-auth/SKILL.md
@@ -12,7 +12,7 @@ description: 'Install and configure Clerk SDK/CLI authentication.
 
   '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Grep
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/plugins/saas-packs/clerk-pack/skills/clerk-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-local-dev-loop/SKILL.md
@@ -12,7 +12,7 @@ description: 'Set up local development workflow with Clerk.
 
   '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Grep
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/plugins/saas-packs/clerk-pack/skills/clerk-migration-deep-dive/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-migration-deep-dive/SKILL.md
@@ -12,7 +12,7 @@ description: 'Migrate from other authentication providers to Clerk.
 
   '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/plugins/saas-packs/clerk-pack/skills/clerk-multi-env-setup/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-multi-env-setup/SKILL.md
@@ -12,7 +12,7 @@ description: 'Configure Clerk for multiple environments (dev, staging, productio
 
   '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/plugins/saas-packs/clerk-pack/skills/clerk-observability/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-observability/SKILL.md
@@ -12,7 +12,7 @@ description: 'Implement monitoring, logging, and observability for Clerk authent
 
   '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/plugins/saas-packs/clerk-pack/skills/clerk-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-performance-tuning/SKILL.md
@@ -12,7 +12,7 @@ description: 'Optimize Clerk authentication performance.
 
   '
 allowed-tools: Read, Write, Edit, Grep
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/plugins/saas-packs/clerk-pack/skills/clerk-prod-checklist/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-prod-checklist/SKILL.md
@@ -12,7 +12,7 @@ description: 'Production readiness checklist for Clerk deployment.
 
   '
 allowed-tools: Read, Write, Edit, Grep, Bash(npm:*)
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/plugins/saas-packs/clerk-pack/skills/clerk-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-reference-architecture/SKILL.md
@@ -12,7 +12,7 @@ description: 'Reference architecture patterns for Clerk authentication.
 
   '
 allowed-tools: Read, Write, Edit, Grep
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/plugins/saas-packs/clerk-pack/skills/clerk-sdk-patterns/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-sdk-patterns/SKILL.md
@@ -12,7 +12,7 @@ description: 'Common Clerk SDK patterns and best practices.
 
   '
 allowed-tools: Read, Write, Edit, Grep
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/plugins/saas-packs/clerk-pack/skills/clerk-security-basics/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-security-basics/SKILL.md
@@ -12,7 +12,7 @@ description: 'Implement security best practices with Clerk authentication.
 
   '
 allowed-tools: Read, Write, Edit, Grep
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/plugins/saas-packs/clerk-pack/skills/clerk-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-upgrade-migration/SKILL.md
@@ -12,7 +12,7 @@ description: 'Manage Clerk SDK version upgrades and handle breaking changes.
 
   '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Grep
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/plugins/saas-packs/clerk-pack/skills/clerk-webhooks-events/SKILL.md
+++ b/plugins/saas-packs/clerk-pack/skills/clerk-webhooks-events/SKILL.md
@@ -12,7 +12,7 @@ description: 'Configure Clerk webhooks and handle authentication events.
 
   '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/plugins/saas-packs/notion-pack/skills/notion-rate-limits/SKILL.md
+++ b/plugins/saas-packs/notion-pack/skills/notion-rate-limits/SKILL.md
@@ -13,7 +13,7 @@ description: 'Manage Notion API rate limits with exponential backoff, queue-base
 
   '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Glob, Grep
-version: 1.37.0
+version: 1.38.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/plugins/saas-packs/supabase-pack/skills/supabase-debug-bundle/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-debug-bundle/SKILL.md
@@ -13,7 +13,7 @@ description: 'Collect Supabase diagnostic info for troubleshooting and support t
   '
 allowed-tools: Read, Bash(npx:*), Bash(node:*), Bash(curl:*), Bash(supabase:*), Bash(tar:*),
   Grep, Glob
-version: 1.52.0
+version: 1.53.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/plugins/saas-packs/supabase-pack/skills/supabase-deploy-integration/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-deploy-integration/SKILL.md
@@ -16,7 +16,7 @@ description: 'Deploy and manage Supabase projects in production. Covers database
 
   '
 allowed-tools: Read, Write, Edit, Bash(npx:supabase), Bash(supabase:*), Bash(curl:*)
-version: 1.52.0
+version: 1.53.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/plugins/saas-packs/supabase-pack/skills/supabase-install-auth/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-install-auth/SKILL.md
@@ -13,7 +13,7 @@ description: 'Install and configure Supabase SDK, CLI, and project authenticatio
   '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Bash(pnpm:*), Bash(pip:*),
   Bash(supabase:*), Grep, Glob
-version: 1.52.0
+version: 1.53.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/plugins/saas-packs/supabase-pack/skills/supabase-local-dev-loop/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-local-dev-loop/SKILL.md
@@ -14,7 +14,7 @@ description: 'Configure Supabase local development with the CLI, Docker, and mig
   '
 allowed-tools: Read, Write, Edit, Bash(npx:*), Bash(supabase:*), Bash(docker:*), Bash(curl:*),
   Grep
-version: 1.52.0
+version: 1.53.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/plugins/saas-packs/supabase-pack/skills/supabase-performance-tuning/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-performance-tuning/SKILL.md
@@ -17,7 +17,7 @@ description: 'Optimize Supabase query performance with indexes, EXPLAIN ANALYZE,
 
   '
 allowed-tools: Read, Write, Edit, Bash(npx:supabase), Bash(supabase:*), Grep
-version: 1.52.0
+version: 1.53.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/plugins/saas-packs/supabase-pack/skills/supabase-policy-guardrails/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-policy-guardrails/SKILL.md
@@ -23,7 +23,7 @@ description: 'Enforce organizational governance for Supabase projects: shared RL
 
   '
 allowed-tools: Read, Write, Edit, Bash(supabase:*), Bash(psql:*), Bash(npx:*), Grep
-version: 1.52.0
+version: 1.53.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/plugins/saas-packs/supabase-pack/skills/supabase-reference-architecture/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-reference-architecture/SKILL.md
@@ -10,7 +10,7 @@ description: "Implement enterprise Supabase reference architectures \u2014 monor
   , \"supabase reference design\",\n\"how to organize supabase at scale\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Bash(supabase:*), Grep,
   Glob
-version: 1.52.0
+version: 1.53.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/plugins/saas-packs/supabase-pack/skills/supabase-reliability-patterns/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-reliability-patterns/SKILL.md
@@ -20,7 +20,7 @@ description: 'Build resilient Supabase integrations: circuit breakers wrapping c
 
   '
 allowed-tools: Read, Write, Edit, Bash(supabase:*), Bash(curl:*), Grep
-version: 1.52.0
+version: 1.53.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/plugins/saas-packs/supabase-pack/skills/supabase-security-basics/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-security-basics/SKILL.md
@@ -16,7 +16,7 @@ description: 'Apply Supabase security best practices: anon vs service_role key s
 
   '
 allowed-tools: Read, Write, Edit, Grep, Bash(supabase:*), Bash(npx supabase:*)
-version: 1.52.0
+version: 1.53.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/plugins/saas-packs/supabase-pack/skills/supabase-upgrade-migration/SKILL.md
+++ b/plugins/saas-packs/supabase-pack/skills/supabase-upgrade-migration/SKILL.md
@@ -7,7 +7,7 @@ description: "Upgrade Supabase SDK and CLI versions with breaking-change detecti
   , \"migrate supabase v2\", \"update supabase SDK\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Bash(pip:*), Bash(supabase:*),
   Bash(git:*), Grep, Glob
-version: 1.52.0
+version: 1.53.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/plugins/testing/browser-compatibility-tester/.claude-plugin/plugin.json
+++ b/plugins/testing/browser-compatibility-tester/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-compatibility-tester",
-  "version": "1.20.0",
+  "version": "2.20.0",
   "description": "Cross-browser testing with Playwright, BrowserStack, Sauce Labs, LambdaTest, and Kobiton - test across Chrome, Firefox, Safari, Edge on real devices",
   "author": {
     "name": "Claude Code Plugin Hub",

--- a/plugins/testing/browser-compatibility-tester/skills/testing-browser-compatibility/SKILL.md
+++ b/plugins/testing/browser-compatibility-tester/skills/testing-browser-compatibility/SKILL.md
@@ -11,7 +11,7 @@ description: 'Test across multiple browsers and devices for cross-browser compat
   '
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(npx playwright:*), Bash(npm:*),
   Bash(curl:*)
-version: 1.20.0
+version: 2.20.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
 tags:

--- a/scripts/auto-bump-changed-plugins.mjs
+++ b/scripts/auto-bump-changed-plugins.mjs
@@ -46,7 +46,11 @@ import { pathToFileURL } from 'node:url';
 // Circular import by design: reconstruct-versions.mjs imports parseVersion/
 // compareVersion from this module. Both modules only export hoisted function
 // declarations and neither runs main() on import, so the cycle is safe.
-import { setCatalogEntryVersion, editSkillFrontmatter } from './reconstruct-versions.mjs';
+import {
+  setCatalogEntryVersion,
+  editSkillFrontmatter,
+  findSkillFiles,
+} from './reconstruct-versions.mjs';
 
 const ROOT = resolve(dirname(new URL(import.meta.url).pathname), '..');
 const SCOPE = '@intentsolutionsio/';
@@ -250,7 +254,13 @@ function planDisplayBump(dir, changedFiles) {
     to,
     pjAbs: pjOld ? pjAbs : null,
     pjOld,
-    skillFiles: changedFiles.filter((f) => f.endsWith('/SKILL.md')),
+    // Stamp ALL of the plugin's SKILL.md files on a display bump, not only the
+    // ones in this PR's diff. Stamping only changed SKILL.md strands sibling
+    // skills' frontmatter one minor behind the plugin/catalog cards every time
+    // a non-SKILL file (command, agent, README) is edited — the exact
+    // skill-card-vs-plugin-card drift this bump exists to prevent. changedFiles
+    // is retained only for the sourceChanged gate upstream.
+    skillFiles: findSkillFiles(dir),
   };
 }
 

--- a/scripts/auto-bump-changed-plugins.test.mjs
+++ b/scripts/auto-bump-changed-plugins.test.mjs
@@ -25,9 +25,25 @@ import {
   setCatalogEntryVersion,
   editCatalogVersions,
   editSkillFrontmatter,
+  findSkillFiles,
 } from './reconstruct-versions.mjs';
 
 const v = (s) => parseVersion(s);
+
+// Recurrence guard: a display bump must stamp EVERY SKILL.md in the plugin,
+// not only the ones in the PR diff — otherwise a non-SKILL edit (command/README)
+// strands sibling skills' frontmatter a minor behind the plugin/catalog cards
+// and the surface drift regrows. planDisplayBump now sources skillFiles from
+// findSkillFiles(dir), so this locks that helper to the "all skills" contract.
+test('findSkillFiles returns every SKILL.md under a multi-skill plugin dir', () => {
+  const files = findSkillFiles('plugins/saas-packs/clerk-pack');
+  assert.ok(Array.isArray(files));
+  assert.ok(files.length > 1, `expected multiple skills, got ${files.length}`);
+  for (const f of files) {
+    assert.ok(f.endsWith('/SKILL.md'), `not a SKILL.md: ${f}`);
+    assert.ok(f.startsWith('plugins/saas-packs/clerk-pack/'), `outside plugin dir: ${f}`);
+  }
+});
 
 test('compareVersion orders by major, then minor, then patch', () => {
   assert.ok(compareVersion(v('1.0.0'), v('0.9.9')) > 0);

--- a/scripts/reconstruct-versions.mjs
+++ b/scripts/reconstruct-versions.mjs
@@ -48,6 +48,7 @@ import { parseVersion, compareVersion } from './auto-bump-changed-plugins.mjs';
 
 const ROOT = resolve(dirname(new URL(import.meta.url).pathname), '..');
 const CATALOG = join(ROOT, '.claude-plugin', 'marketplace.extended.json');
+const CLI_CATALOG = join(ROOT, '.claude-plugin', 'marketplace.json');
 
 function fmt(v) {
   return `${v.major}.${v.minor}.${v.patch}`;
@@ -239,7 +240,7 @@ export function editSkillFrontmatter(raw, newVersion) {
   return { old, out: raw.slice(0, 4) + lines.join('\n') + raw.slice(end) };
 }
 
-function findSkillFiles(dir) {
+export function findSkillFiles(dir) {
   const out = [];
   const walk = (d) => {
     for (const ent of readdirSync(join(ROOT, d), { withFileTypes: true })) {
@@ -304,7 +305,20 @@ function main() {
     const commits = history.get(p.dir)?.commits ?? [];
     // Oldest commit = the one that introduced the dir → creation, not an update.
     const updates = Math.max(0, commits.length - 1);
-    const existing = parseVersion(p.catalogVersion) || { major: 1, minor: 0, patch: 0 };
+    // Floor = the HIGHEST of catalog + plugin.json. The plugin.json can lead
+    // the catalog (e.g. a hand-bump that never reached the catalog); flooring on
+    // the catalog alone silently DOWNGRADED such plugins — the 2026-07
+    // reconstruction bug (claude-never-forgets 1.0.0→0.21.0 etc.). Taking the
+    // higher of the two, and its major, keeps a leading plugin.json's major.
+    const catV = parseVersion(p.catalogVersion) || { major: 1, minor: 0, patch: 0 };
+    let pjV = null;
+    try {
+      const pjRaw = readFileSync(join(ROOT, p.dir, '.claude-plugin', 'plugin.json'), 'utf-8');
+      pjV = parseVersion(JSON.parse(pjRaw).version);
+    } catch {
+      /* no plugin.json (vendored sub-marketplace) — the catalog is the floor */
+    }
+    const existing = pjV && compareVersion(pjV, catV) > 0 ? pjV : catV;
     const derived = { major: existing.major, minor: updates, patch: 0 };
     const finalV = compareVersion(derived, existing) > 0 ? derived : existing;
     rows.push({
@@ -319,22 +333,65 @@ function main() {
 
   // -------------------------------------------------------------- check mode
   if (check) {
-    let bad = 0;
-    for (const p of plugins) {
-      const pj = join(ROOT, p.dir, '.claude-plugin', 'plugin.json');
-      if (!existsSync(pj)) continue;
-      let v;
-      try {
-        v = JSON.parse(readFileSync(pj, 'utf-8')).version;
-      } catch {
-        continue;
+    // Compare ALL FOUR display surfaces to the extended-catalog version (the
+    // authority reconstruction writes): plugin.json, the generated CLI catalog
+    // (marketplace.json), and EVERY SKILL.md frontmatter under the plugin dir.
+    // The pre-2026-07 check read only plugin.json vs catalog, so it printed
+    // "All surfaces agree" while SKILL.md frontmatter drifted — a false pass.
+    let cliBySource = new Map();
+    try {
+      const cli = JSON.parse(readFileSync(CLI_CATALOG, 'utf-8'));
+      for (const e of cli.plugins || []) {
+        if (typeof e.source === 'string') cliBySource.set(e.source, e.version);
       }
-      if (v && p.catalogVersion && v !== p.catalogVersion) {
+    } catch {
+      /* CLI catalog unreadable — skip that surface rather than crash */
+    }
+    let bad = 0;
+    const noPluginJson = [];
+    for (const p of plugins) {
+      const want = p.catalogVersion;
+      if (!want) continue;
+      const mismatches = [];
+
+      const pj = join(ROOT, p.dir, '.claude-plugin', 'plugin.json');
+      if (existsSync(pj)) {
+        try {
+          const v = JSON.parse(readFileSync(pj, 'utf-8')).version;
+          if (v && v !== want) mismatches.push(`plugin.json=${v}`);
+        } catch {
+          mismatches.push('plugin.json=UNPARSEABLE');
+        }
+      } else {
+        // A catalog entry whose dir has no plugin.json (e.g. the vendored axiom
+        // sub-marketplace). Surface it instead of silently skipping.
+        noPluginJson.push(p.dir);
+      }
+
+      const cliV = cliBySource.get(p.source);
+      if (cliV && cliV !== want) mismatches.push(`marketplace.json=${cliV}`);
+
+      for (const rel of findSkillFiles(p.dir)) {
+        const res = editSkillFrontmatter(readFileSync(join(ROOT, rel), 'utf-8'), want);
+        if (res.old && res.old !== want) mismatches.push(`${rel}=${res.old}`);
+      }
+
+      if (mismatches.length) {
         bad++;
-        console.log(`DISAGREE ${p.dir}: plugin.json=${v} catalog=${p.catalogVersion}`);
+        console.log(`DISAGREE ${p.dir}: catalog=${want} · ${mismatches.join(' · ')}`);
       }
     }
-    console.log(bad ? `\n${bad} plugin(s) disagree across surfaces.` : 'All surfaces agree.');
+    if (noPluginJson.length) {
+      console.log(
+        `\nNOTE: ${noPluginJson.length} catalog dir(s) have no plugin.json (vendored sub-marketplace?) ` +
+          `and were not version-checked: ${noPluginJson.join(', ')}`,
+      );
+    }
+    console.log(
+      bad
+        ? `\n${bad} plugin(s) disagree across surfaces (plugin.json / marketplace.json / SKILL.md vs catalog).`
+        : 'All surfaces agree (plugin.json + marketplace.json + SKILL.md frontmatter vs catalog).',
+    );
     process.exit(bad ? 2 : 0);
   }
 

--- a/skills/.curated/clerk-ci-integration/SKILL.md
+++ b/skills/.curated/clerk-ci-integration/SKILL.md
@@ -12,7 +12,7 @@ description: 'Configure Clerk CI/CD integration with GitHub Actions and testing.
 
   '
 allowed-tools: Read, Write, Edit, Bash(gh:*)
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/skills/.curated/clerk-common-errors/SKILL.md
+++ b/skills/.curated/clerk-common-errors/SKILL.md
@@ -12,7 +12,7 @@ description: 'Troubleshoot common Clerk errors and issues.
 
   '
 allowed-tools: Read, Write, Edit, Grep, Bash(npm:*)
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/skills/.curated/clerk-core-workflow-a/SKILL.md
+++ b/skills/.curated/clerk-core-workflow-a/SKILL.md
@@ -12,7 +12,7 @@ description: 'Implement user sign-up and sign-in flows with Clerk.
 
   '
 allowed-tools: Read, Write, Edit, Grep
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/skills/.curated/clerk-core-workflow-b/SKILL.md
+++ b/skills/.curated/clerk-core-workflow-b/SKILL.md
@@ -12,7 +12,7 @@ description: 'Implement session management and middleware with Clerk.
 
   '
 allowed-tools: Read, Write, Edit, Grep
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/skills/.curated/clerk-data-handling/SKILL.md
+++ b/skills/.curated/clerk-data-handling/SKILL.md
@@ -12,7 +12,7 @@ description: 'Handle user data, privacy, and GDPR compliance with Clerk.
 
   '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/skills/.curated/clerk-debug-bundle/SKILL.md
+++ b/skills/.curated/clerk-debug-bundle/SKILL.md
@@ -12,7 +12,7 @@ description: 'Collect comprehensive debug information for Clerk issues.
 
   '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(node:*), Grep
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/skills/.curated/clerk-deploy-integration/SKILL.md
+++ b/skills/.curated/clerk-deploy-integration/SKILL.md
@@ -12,7 +12,7 @@ description: 'Configure Clerk for deployment on various platforms.
 
   '
 allowed-tools: Read, Write, Edit, Bash(vercel:*), Bash(netlify:*), Grep
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/skills/.curated/clerk-enterprise-rbac/SKILL.md
+++ b/skills/.curated/clerk-enterprise-rbac/SKILL.md
@@ -13,7 +13,7 @@ description: 'Configure enterprise SSO, role-based access control, and organizat
 
   '
 allowed-tools: Read, Write, Edit, Grep
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/skills/.curated/clerk-hello-world/SKILL.md
+++ b/skills/.curated/clerk-hello-world/SKILL.md
@@ -12,7 +12,7 @@ description: 'Create your first authenticated request with Clerk.
 
   '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/skills/.curated/clerk-incident-runbook/SKILL.md
+++ b/skills/.curated/clerk-incident-runbook/SKILL.md
@@ -12,7 +12,7 @@ description: 'Manage incident response for Clerk authentication issues.
 
   '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(curl:*), Grep
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/skills/.curated/clerk-local-dev-loop/SKILL.md
+++ b/skills/.curated/clerk-local-dev-loop/SKILL.md
@@ -12,7 +12,7 @@ description: 'Set up local development workflow with Clerk.
 
   '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Grep
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/skills/.curated/clerk-migration-deep-dive/SKILL.md
+++ b/skills/.curated/clerk-migration-deep-dive/SKILL.md
@@ -12,7 +12,7 @@ description: 'Migrate from other authentication providers to Clerk.
 
   '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/skills/.curated/clerk-multi-env-setup/SKILL.md
+++ b/skills/.curated/clerk-multi-env-setup/SKILL.md
@@ -12,7 +12,7 @@ description: 'Configure Clerk for multiple environments (dev, staging, productio
 
   '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/skills/.curated/clerk-observability/SKILL.md
+++ b/skills/.curated/clerk-observability/SKILL.md
@@ -12,7 +12,7 @@ description: 'Implement monitoring, logging, and observability for Clerk authent
 
   '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/skills/.curated/clerk-performance-tuning/SKILL.md
+++ b/skills/.curated/clerk-performance-tuning/SKILL.md
@@ -12,7 +12,7 @@ description: 'Optimize Clerk authentication performance.
 
   '
 allowed-tools: Read, Write, Edit, Grep
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/skills/.curated/clerk-prod-checklist/SKILL.md
+++ b/skills/.curated/clerk-prod-checklist/SKILL.md
@@ -12,7 +12,7 @@ description: 'Production readiness checklist for Clerk deployment.
 
   '
 allowed-tools: Read, Write, Edit, Grep, Bash(npm:*)
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/skills/.curated/clerk-reference-architecture/SKILL.md
+++ b/skills/.curated/clerk-reference-architecture/SKILL.md
@@ -12,7 +12,7 @@ description: 'Reference architecture patterns for Clerk authentication.
 
   '
 allowed-tools: Read, Write, Edit, Grep
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/skills/.curated/clerk-sdk-patterns/SKILL.md
+++ b/skills/.curated/clerk-sdk-patterns/SKILL.md
@@ -12,7 +12,7 @@ description: 'Common Clerk SDK patterns and best practices.
 
   '
 allowed-tools: Read, Write, Edit, Grep
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/skills/.curated/clerk-security-basics/SKILL.md
+++ b/skills/.curated/clerk-security-basics/SKILL.md
@@ -12,7 +12,7 @@ description: 'Implement security best practices with Clerk authentication.
 
   '
 allowed-tools: Read, Write, Edit, Grep
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/skills/.curated/clerk-upgrade-migration/SKILL.md
+++ b/skills/.curated/clerk-upgrade-migration/SKILL.md
@@ -12,7 +12,7 @@ description: 'Manage Clerk SDK version upgrades and handle breaking changes.
 
   '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(pnpm:*), Grep
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/skills/.curated/clerk-webhooks-events/SKILL.md
+++ b/skills/.curated/clerk-webhooks-events/SKILL.md
@@ -12,7 +12,7 @@ description: 'Configure Clerk webhooks and handle authentication events.
 
   '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Grep
-version: 1.13.0
+version: 1.14.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/skills/.curated/code-formatter/SKILL.md
+++ b/skills/.curated/code-formatter/SKILL.md
@@ -12,7 +12,7 @@ description: 'Execute automatically formats and validates code files using Prett
 
   '
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(cmd:*)
-version: 1.26.0
+version: 2.26.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
 tags:

--- a/skills/.curated/memory/SKILL.md
+++ b/skills/.curated/memory/SKILL.md
@@ -11,7 +11,7 @@ description: 'Execute extract and use project memories from previous sessions fo
 
   '
 allowed-tools: Read, Write
-version: 0.21.0
+version: 1.21.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
 tags:

--- a/skills/.curated/notion-rate-limits/SKILL.md
+++ b/skills/.curated/notion-rate-limits/SKILL.md
@@ -13,7 +13,7 @@ description: 'Manage Notion API rate limits with exponential backoff, queue-base
 
   '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Glob, Grep
-version: 1.37.0
+version: 1.38.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/skills/.curated/supabase-debug-bundle/SKILL.md
+++ b/skills/.curated/supabase-debug-bundle/SKILL.md
@@ -13,7 +13,7 @@ description: 'Collect Supabase diagnostic info for troubleshooting and support t
   '
 allowed-tools: Read, Bash(npx:*), Bash(node:*), Bash(curl:*), Bash(supabase:*), Bash(tar:*),
   Grep, Glob
-version: 1.52.0
+version: 1.53.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/skills/.curated/supabase-deploy-integration/SKILL.md
+++ b/skills/.curated/supabase-deploy-integration/SKILL.md
@@ -16,7 +16,7 @@ description: 'Deploy and manage Supabase projects in production. Covers database
 
   '
 allowed-tools: Read, Write, Edit, Bash(npx:supabase), Bash(supabase:*), Bash(curl:*)
-version: 1.52.0
+version: 1.53.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/skills/.curated/supabase-install-auth/SKILL.md
+++ b/skills/.curated/supabase-install-auth/SKILL.md
@@ -13,7 +13,7 @@ description: 'Install and configure Supabase SDK, CLI, and project authenticatio
   '
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Bash(pnpm:*), Bash(pip:*),
   Bash(supabase:*), Grep, Glob
-version: 1.52.0
+version: 1.53.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/skills/.curated/supabase-local-dev-loop/SKILL.md
+++ b/skills/.curated/supabase-local-dev-loop/SKILL.md
@@ -14,7 +14,7 @@ description: 'Configure Supabase local development with the CLI, Docker, and mig
   '
 allowed-tools: Read, Write, Edit, Bash(npx:*), Bash(supabase:*), Bash(docker:*), Bash(curl:*),
   Grep
-version: 1.52.0
+version: 1.53.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/skills/.curated/supabase-performance-tuning/SKILL.md
+++ b/skills/.curated/supabase-performance-tuning/SKILL.md
@@ -17,7 +17,7 @@ description: 'Optimize Supabase query performance with indexes, EXPLAIN ANALYZE,
 
   '
 allowed-tools: Read, Write, Edit, Bash(npx:supabase), Bash(supabase:*), Grep
-version: 1.52.0
+version: 1.53.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/skills/.curated/supabase-policy-guardrails/SKILL.md
+++ b/skills/.curated/supabase-policy-guardrails/SKILL.md
@@ -23,7 +23,7 @@ description: 'Enforce organizational governance for Supabase projects: shared RL
 
   '
 allowed-tools: Read, Write, Edit, Bash(supabase:*), Bash(psql:*), Bash(npx:*), Grep
-version: 1.52.0
+version: 1.53.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/skills/.curated/supabase-reference-architecture/SKILL.md
+++ b/skills/.curated/supabase-reference-architecture/SKILL.md
@@ -10,7 +10,7 @@ description: "Implement enterprise Supabase reference architectures \u2014 monor
   , \"supabase reference design\",\n\"how to organize supabase at scale\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Bash(supabase:*), Grep,
   Glob
-version: 1.52.0
+version: 1.53.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/skills/.curated/supabase-reliability-patterns/SKILL.md
+++ b/skills/.curated/supabase-reliability-patterns/SKILL.md
@@ -20,7 +20,7 @@ description: 'Build resilient Supabase integrations: circuit breakers wrapping c
 
   '
 allowed-tools: Read, Write, Edit, Bash(supabase:*), Bash(curl:*), Grep
-version: 1.52.0
+version: 1.53.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/skills/.curated/supabase-security-basics/SKILL.md
+++ b/skills/.curated/supabase-security-basics/SKILL.md
@@ -16,7 +16,7 @@ description: 'Apply Supabase security best practices: anon vs service_role key s
 
   '
 allowed-tools: Read, Write, Edit, Grep, Bash(supabase:*), Bash(npx supabase:*)
-version: 1.52.0
+version: 1.53.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/skills/.curated/supabase-upgrade-migration/SKILL.md
+++ b/skills/.curated/supabase-upgrade-migration/SKILL.md
@@ -7,7 +7,7 @@ description: "Upgrade Supabase SDK and CLI versions with breaking-change detecti
   , \"migrate supabase v2\", \"update supabase SDK\".\n"
 allowed-tools: Read, Write, Edit, Bash(npm:*), Bash(npx:*), Bash(pip:*), Bash(supabase:*),
   Bash(git:*), Grep, Glob
-version: 1.52.0
+version: 1.53.0
 license: MIT
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 tags:

--- a/skills/.curated/testing-browser-compatibility/SKILL.md
+++ b/skills/.curated/testing-browser-compatibility/SKILL.md
@@ -11,7 +11,7 @@ description: 'Test across multiple browsers and devices for cross-browser compat
   '
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash(npx playwright:*), Bash(npm:*),
   Bash(curl:*)
-version: 1.20.0
+version: 2.20.0
 author: Jeremy Longshore <jeremy@intentsolutions.io>
 license: MIT
 tags:


### PR DESCRIPTION
## What

Repairs version-surface issues found by an adversarial re-audit of the reconstruction work (PR #1086), and closes the holes that let them recur. **Display version strings only — zero `package.json` diffs, zero mirror-dir changes, no validator/tier changes.**

## Why + decision rationale

The audit found the reconstruction's own verifier was lying and drift had already regrown:

1. **`reconstruct-versions.mjs --check` was blind.** It compared only `plugin.json` vs the catalog — never SKILL.md frontmatter or `marketplace.json` — yet printed *"All surfaces agree."* Extended it to check **all three** display surfaces against the catalog and to **surface** (not silently skip) catalog dirs with no `plugin.json` (the vendored `axiom` sub-marketplace). *Chose extending the one canonical checker over adding a new gate so the single verifier tells the truth.*
2. **33 SKILL.md files had drifted** a minor behind their pack (clerk 22×`1.13.0`→`1.14.0`, supabase 10×`1.52.0`→`1.53.0`, notion 1×`1.37.0`→`1.38.0`) — reintroduced by per-pack bump PRs that moved plugin.json+catalog but only some sibling SKILL.md. Restamped (version field only, **no body edits**).
3. **3 plugins were silently downgraded a full major** by #1086 (`claude-never-forgets` 1.0.0→0.21.0, `formatter` 2.1.0→1.26.0, `browser-compatibility-tester` 2.0.0→1.20.0) because the reconstruction floored on the *catalog* value alone while their plugin.json led it. Fixed the floor to `max(catalog, plugin.json)` and restored the three to **1.21.0 / 2.26.0 / 2.20.0** (leading major + minor = lifetime update count) across every surface.
4. **auto-bump re-stamped only PR-diff SKILL.md** → a non-SKILL edit stranded sibling skills and regrew the drift. `planDisplayBump` now sources `skillFiles` from `findSkillFiles(dir)` — every skill in the plugin moves in lockstep. *Chose an all-skills walk because the display version is a per-plugin fact, not per-file.*

## Layer(s) touched

Version-reconstruction tooling (`scripts/reconstruct-versions.mjs`, `scripts/auto-bump-changed-plugins.mjs`) + display-surface data (36 SKILL.md, 3 plugin.json, both catalogs). **No change** to `validate-skills-schema.py`, required-fields, or tier semantics.

## Verification & evidence

- `node scripts/reconstruct-versions.mjs --check` → **"All surfaces agree (plugin.json + marketplace.json + SKILL.md frontmatter vs catalog)"**, exit 0 — was falsely green before with 33 files drifted.
- `node --test scripts/auto-bump-changed-plugins.test.mjs` → **15/15** (added a regression test locking `findSkillFiles` to the all-skills contract).
- 3 restored plugins validate **A** (98 / 99 / 100) at marketplace tier.
- `git diff`: **0** `package.json`, **0** `.source.json`-mirror dirs, **0** build artifacts. 44 files = 2 catalogs + 3 plugin.json + 3 scripts + 36 SKILL.md.

## Risk / operational impact

Display version strings only (skill cards, plugin cards, `/plugin` CLI browser). No runtime, security, or npm-publish impact — `package.json` untouched, so `[skip auto-bump]` in the title prevents a mass republish. A public catalog version moving backward (finding 3) can confuse update-detection; this reverses it.

## Follow-up / deferred

- `axiom` sub-marketplace has no `plugin.json` (its `package.json`/inner marketplace = 0.1.3 vs catalog 0.3.0) — now *reported* by `--check` rather than fixed; normalizing its layout is a separate small task.

- Jeremy Longshore
intentsolutions.io
