### PR TITLE
fix(ci): stop MiniMax A-grade coach failing on multi-skill PRs (heredoc delimiter)

### DIFF
--- a/.github/workflows/minimax-review.yml
+++ b/.github/workflows/minimax-review.yml
@@ -249,13 +249,21 @@ jobs:
               >> "$REPORT" || true
             echo "" >> "$REPORT"
           done <<< "$CHANGED"
-          # Bound the prompt payload.
+          # Bound the prompt payload. `head -c` cuts on a BYTE boundary, which can
+          # leave the capped file without a trailing newline; without one the
+          # closing heredoc delimiter is appended to the last content line instead
+          # of standing alone, and the runner fails with "Matching delimiter not
+          # found" (seen on PRs with enough changed skills to fill the cap, e.g.
+          # #1098's 36 SKILL.md). Force a trailing newline, and use a per-run
+          # random delimiter so validator output can never collide with it.
           head -c 16000 "$REPORT" > "$REPORT.cap"
+          printf '\n' >> "$REPORT.cap"
+          DELIM="MINIMAX_EOF_$(date +%s)_${RANDOM}"
           echo "has_changes=true" >> "$GITHUB_OUTPUT"
           {
-            echo "report<<__MINIMAX_EOF__"
+            echo "report<<${DELIM}"
             cat "$REPORT.cap"
-            echo "__MINIMAX_EOF__"
+            echo "${DELIM}"
           } >> "$GITHUB_OUTPUT"
 
       - name: MiniMax A-grade coach (validator-grounded)


### PR DESCRIPTION
## What

Fixes the intermittent failure of the **MiniMax A-grade coach** lane (`minimax-review.yml`) on PRs that change many skills. **MiniMax itself is correctly wired** — this was a shell/heredoc bug in one advisory lane, not an auth/API/config problem.

## Why + decision rationale

The lane caps its validator report with `head -c 16000` (a **byte** cut) and writes it to `$GITHUB_OUTPUT` via a `report<<__MINIMAX_EOF__` heredoc. When the cap lands mid-line the capped file has **no trailing newline**, so the closing `__MINIMAX_EOF__` gets appended to the last content line instead of standing alone. The runner then aborts:

```
##[error]Unable to process file command 'output' successfully.
##[error]Invalid value. Matching delimiter not found '__MINIMAX_EOF__'
```

— and the step dies **before** the MiniMax API call. It only trips on PRs with enough changed `SKILL.md` to fill the 16 KB cap (e.g. #1098's 36 files), which is exactly why the lane looked "broken" while the **Review** and **Adversarial** lanes (the real MiniMax calls) stayed green.

Fix: force a trailing newline on the capped file so the closing delimiter is always on its own line, and use a **per-run random delimiter** (`MINIMAX_EOF_<epoch>_<RANDOM>`) so validator output can't collide with it. *Chose newline-guarantee + random delimiter over dropping the cap because the 16 KB prompt bound is deliberate.*

## Layer(s) touched

CI only — `.github/workflows/minimax-review.yml`, the `A-grade coach` job's `Run the validator on changed skills` step. Output key `report` unchanged, so the downstream `MiniMax A-grade coach` consumer step is untouched.

## Verification & evidence

- Root cause from the live failure log (run 29670798284, #1098): `Matching delimiter not found '__MINIMAX_EOF__'`.
- Confirmed MiniMax is configured: `MINIMAX_API_KEY` secret (set 2026-07-16), `ENABLE_MINIMAX_REVIEW=true`, `MINIMAX_MODEL=MiniMax-M3`; the Review + Adversarial lanes pass on real PRs (#1085).
- `actionlint .github/workflows/minimax-review.yml` → clean. Added lines are bash-safe under `set -uo pipefail` (`printf`, `date +%s`, `$RANDOM`).

## Risk / rollback

Advisory lane only (not in `ci-required`) — never blocked merges; the impact was that the validator-grounded coaching silently didn't run on the largest PRs. Rollback = revert this one-file change.

## Follow-up

This PR changes no skills, so its own A-grade-coach lane takes the `has_changes=false` early-exit — the fix's real exercise is the next multi-skill PR. No bead needed.

- Jeremy Longshore
intentsolutions.io
