### PR TITLE
feat: add UIZZE external skill source

### DIFF
--- a/scripts/scan-allowlist.txt
+++ b/scripts/scan-allowlist.txt
@@ -77,6 +77,10 @@ plugins/mcp/governed-second-brain/plugin-runtime/governed-brain.cjs:dynamic-exec
 # ── hyperflow orchestrator skill: upstream web-research feature. ──
 plugins/ai-agency/hyperflow/skills/hyperflow/SKILL.md:allowed-tools-network  upstream v5.8.x added WebFetch/WebSearch to the orchestrator skill for its web-research feature (skills/hyperflow/web-research.md); mirror content hand-reviewed 2026-07-10 (evidence gate on #1008 + the be6ae2d3->eae6e34c5 delta review) — external mirror, upstream's design, no credential surface
 
+# ── UIZZE free catalogue workflow — vetted 2026-07-22 @ upstream c95111fd1517. ──
+plugins/design/uizze/skills/anti-ui-slop/SKILL.md:allowed-tools-network  WebFetch is limited to gathering structural UI evidence from the documented public https://uizze.com catalogue; the complete free workflow requires no account, token, MCP, script, or executable, and the skill forbids copying proprietary assets
+sources.yaml:sources-change-unscanned  UIZZE vetted per the 699 playbook @ samuelbushi/uizze c95111fd1517 (2026-07-22): all 5 admitted files read; markdown-only tier with no scripts/hooks/MCP config; scanner 0 REFUSE / 1 CHALLENGE (WebFetch to documented public catalogue, signed off above) / 0 FLAG; schema 3.15.2 grade A 90/100, unicode hygiene clean, MIT verified; author account active since 2018 with 101 public repos and external site; include globs root-anchored and dry-run matched exactly 5 files
+
 # ── Skill Refiner plugin: the 3-layer hook architecture IS the product. ──
 # /j-rig is the eval-guided SKILL.md improvement loop; its sinker/line/hook hooks
 # are the reviewed, intended feature (not an injected payload). They only invoke

--- a/scripts/scan-allowlist.txt
+++ b/scripts/scan-allowlist.txt
@@ -79,7 +79,7 @@ plugins/ai-agency/hyperflow/skills/hyperflow/SKILL.md:allowed-tools-network  ups
 
 # ── UIZZE free catalogue workflow — vetted 2026-07-22 @ upstream c95111fd1517. ──
 plugins/design/uizze/skills/anti-ui-slop/SKILL.md:allowed-tools-network  WebFetch is limited to gathering structural UI evidence from the documented public https://uizze.com catalogue; the complete free workflow requires no account, token, MCP, script, or executable, and the skill forbids copying proprietary assets
-sources.yaml:sources-change-unscanned  UIZZE vetted per the 699 playbook @ samuelbushi/uizze c95111fd1517 (2026-07-22): all 5 admitted files read; markdown-only tier with no scripts/hooks/MCP config; scanner 0 REFUSE / 1 CHALLENGE (WebFetch to documented public catalogue, signed off above) / 0 FLAG; schema 3.15.2 grade A 90/100, unicode hygiene clean, MIT verified; author account active since 2018 with 101 public repos and external site; include globs root-anchored and dry-run matched exactly 5 files
+sources.yaml:sources-change-unscanned  UIZZE vetted per the 699 playbook @ uizze/uizze c95111fd1517 (2026-07-22): all 5 admitted files read; markdown-only tier with no scripts/hooks/MCP config; scanner 0 REFUSE / 1 CHALLENGE (WebFetch to documented public catalogue, signed off above) / 0 FLAG; schema 3.15.2 grade A 90/100, unicode hygiene clean, MIT verified; author account active since 2018 with 101 public repos and external site; include globs root-anchored and dry-run matched exactly 5 files
 
 # ── Skill Refiner plugin: the 3-layer hook architecture IS the product. ──
 # /j-rig is the eval-guided SKILL.md improvement loop; its sinker/line/hook hooks

--- a/sources.yaml
+++ b/sources.yaml
@@ -1710,6 +1710,41 @@ sources:
       - '.git/**'
       - '*.log'
 
+  # ============================================================
+  # UIZZE (Samuel Bushi)
+  # https://github.com/samuelbushi/uizze
+  # Submission: #1104
+  # ============================================================
+
+  - name: uizze
+    description: STOP UI SLOP. Ground Claude Code in 800,000+ real web and iOS screens, a product-specific design contract, required states, and a hard finish gate.
+    repo: samuelbushi/uizze
+    source_path: .
+    target_path: plugins/design/uizze
+    author:
+      name: UIZZE
+      github: samuelbushi
+      email: business@uizze.com
+    license: MIT
+    category: design
+    verified: false
+    keywords:
+      - ui-design
+      - frontend
+      - design-systems
+      - code-quality
+      - anti-slop
+    include:
+      - '/.claude-plugin/plugin.json'
+      - '/.claude-plugin/marketplace.json'
+      - '/skills/anti-ui-slop/SKILL.md'
+      - '/README.md'
+      - '/LICENSE'
+    exclude:
+      - '/.git/**'
+      - '**/node_modules/**'
+      - '**/*.log'
+
 # Sync configuration
 config:
   # Branch to sync from (default: main)

--- a/sources.yaml
+++ b/sources.yaml
@@ -1712,13 +1712,13 @@ sources:
 
   # ============================================================
   # UIZZE (Samuel Bushi)
-  # https://github.com/samuelbushi/uizze
+  # https://github.com/uizze/uizze
   # Submission: #1104
   # ============================================================
 
   - name: uizze
     description: STOP UI SLOP. Ground Claude Code in 800,000+ real web and iOS screens, a product-specific design contract, required states, and a hard finish gate.
-    repo: samuelbushi/uizze
+    repo: uizze/uizze
     source_path: .
     target_path: plugins/design/uizze
     author:


### PR DESCRIPTION
## Type of Change

- [x] New external plugin source
- [x] Configuration change
- [ ] Vendored plugin submission
- [ ] Marketplace website update

## Description

Summary: Register the existing public UIZZE plugin as a Path B external source. The upstream repository remains the source of truth and the weekly sync mirrors exactly five root-anchored files into `plugins/design/uizze`.

Motivation: Claude Code can produce a working interface that still defaults to interchangeable card grids, filler metrics, missing states, weak hierarchy, and unverified responsive behavior. The free `anti-ui-slop` skill turns those concerns into an evidence-backed design contract and blocking finish gate.

Closes #1104

## Submission Standard

- [x] Links the required submission issue.
- [x] Uses the documented Path B external-source route.
- [x] Keeps `verified: false` pending maintainer vetting and does not set `curated`.
- [x] Upstream contains README.md, LICENSE, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and one schema-compliant skill.
- [x] Vetted per `000-docs/699-DR-GUID-external-source-vetting-playbook.md`.

## External-source vet evidence

- Vetted commit: `samuelbushi/uizze@c95111fd15179a792e401345ee0cf9bd62b18638`.
- Author identity: GitHub account active since 2018, 101 public repositories, external site at `samuelbushi.com`; contributor discloses that they maintain UIZZE.
- Typosquat check: no `uizze` or `anti-ui-slop` collision exists in the current catalog.
- License: MIT, present in the admitted root `LICENSE`.
- Files read: all five admitted files, including both manifests, SKILL.md, README.md, and LICENSE.
- Tier: markdown-only. No scripts, executables, hooks, MCP configuration, environment files, or dependencies are admitted.
- Globs: every include is root-anchored; nested and unrelated upstream files cannot enter the mirror.
- Dry run: exactly five files at `c95111fd1517`, no unsupported glob warning, new lock baseline identified.
- Content scan: 0 REFUSE, 1 CHALLENGE, 0 FLAG. The single challenge is the declared `WebFetch` capability used to browse the documented public `https://uizze.com` catalogue. It is narrowly signed off in `scan-allowlist.txt`; no credential is required for the free workflow.

## Plugin Details

- Name: `uizze`
- Skill: `anti-ui-slop`
- Category: `design`
- Skill version: `1.1.0`
- Target: `plugins/design/uizze`
- Homepage: https://uizze.com
- Keywords: `ui-design`, `frontend`, `design-systems`, `code-quality`, `anti-slop`
- Credentials: none for the complete free workflow
- Scripts, hooks, commands, agents, MCP configs: none admitted

## Testing Evidence

Test environment: macOS, Node v22.20.0, pnpm 9.15.9, Python 3.9.6.

Passed:

```text
python YAML entry assertions
node scripts/sync-lint-ignores.mjs --check-source-anchoring --base=upstream/main
pnpm exec prettier --check sources.yaml
node scripts/scan-synced-content.mjs --changed-only --base=upstream/main
node scripts/sync-external.mjs --dry-run --source=uizze --strict
python3 scripts/validate-skills-schema.py --marketplace --verbose <upstream>/skills/anti-ui-slop/SKILL.md
python3 scripts/validate-unicode-hygiene.py <upstream>/skills/anti-ui-slop/SKILL.md
git diff --check
```

Results:

- External sync dry-run: five files, one new pinned baseline, no refusals or unsupported globs.
- Marketplace validator schema 3.15.2: grade A, 90/100, zero errors.
- Unicode hygiene: zero blockers, majors, or minors.
- Changed-content security gate: no blocking findings; the one-shot source vet waiver is honored.
- `./scripts/quick-test.sh`: dependency install, build, and lint passed. Its repository-wide standard-tier validator reported the existing baseline of 414 errors; the log contains no UIZZE entry because this PR intentionally adds only the source pointer. The focused UIZZE marketplace validation above passes.

## Security Considerations

- [x] No hardcoded secrets, tokens, private keys, or credentials.
- [x] No scripts, command execution, hooks, dynamic evaluation, or MCP auto-configuration.
- [x] No URL shorteners, tracking parameters, encoded payloads, or non-HTTPS endpoints.
- [x] Free workflow does not require authentication or network credentials.
- [x] Real interfaces are structural evidence only; the skill forbids copying branding, proprietary text, imagery, or exact layouts.
- [x] Optional UIZZE automation is mentioned once only after the complete free workflow and is never represented as connected without an actual host result.

## Breaking Changes

- [x] No breaking changes.

## Performance Impact

- [x] No runtime impact. This PR adds one source record and scan evidence only.

## Rollback Plan

Remove the `uizze` source entry and its scoped `allowed-tools-network` waiver. No existing catalog plugin or runtime code is modified by this PR.

## Confirmation

- [x] I have the right to submit the upstream MIT-licensed files.
- [x] I have read the contribution guidelines, skill specification, security playbook, and Code of Conduct.
- [x] Allow edits by maintainers is enabled on the personal fork.
