### PR TITLE
feat(marketplace): Killer Skill of the Week — no-ai-slop (2026-W30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,17 +36,17 @@ Or use Claude's built-in command:
 
 <!-- KILLER-SKILL:START — do not edit; run `node scripts/render-spotlight.mjs` -->
 
-> **Killer Skill of the Week** — [tonone](https://github.com/tonone-ai/tonone) by [tonone-ai](https://github.com/tonone-ai)
+> **Killer Skill of the Week** — [no-ai-slop](https://github.com/petergyang/no-ai-slop) by [Peter Yang](https://github.com/petergyang)
 >
-> **A 23-agent engineering and product team that ships from one session — two commands, zero meetings**
+> **Strip AI slop from any draft — named-pattern edits that keep the writer's real voice**
 >
-> tonone turns Claude Code into a full delivery team: 23 specialist agents (architect, reviewers, product, QA and the rest of the org chart) coordinated through 125 skills, so one session runs discovery, build, review, and ship without you playing project manager between tools. The mirror featured here is the curated cut — every one of its 114 agent definitions verifies clean at the kernel-strict frontmatter floor in the latest inventory run, preserved by the marketplace's never-clobber freeze. MIT-licensed and actively developed upstream; a frontmatter sweep for the skill tier is offered upstream and the roster works as-is today.
+> no-ai-slop does two jobs and refuses to fake a third. In Edit mode it makes the minimum effective edit — cutting throat-clearing, weak verbs, and abstract nouns while deliberately preserving the writer's cadence, bluntness, humor, and honest admissions, so a rough draft still sounds like the same person afterward. In Detect mode it names each AI-slop pattern it finds, quotes the offending line, and gives the fix in a few words — and pointedly does NOT score the draft or guess whether an AI wrote it. That restraint is the whole point: AI detectors guess; named patterns are evidence the reader can check. MIT-licensed, single focused skill, actively maintained by Peter Yang.
 >
-> _"One session. Two commands. Full team. Zero meetings."_ — tonone-ai
+> _"AI detectors guess. Named patterns are evidence the user can check."_ — Peter Yang
 >
-> Grade: A | Week of July 10, 2026 (W28) | [View on GitHub](https://github.com/tonone-ai/tonone)
+> Grade: A | Week of July 22, 2026 (W30) | [View on GitHub](https://github.com/petergyang/no-ai-slop)
 >
-> Previous picks: [mnemos](https://github.com/polyxmedia/mnemos), [databricks-pack](https://tonsofskills.com/plugins/databricks-pack), [kobiton-automate](https://tonsofskills.com/plugins/kobiton-automate), [skyvern](https://github.com/Skyvern-AI/skyvern), [code-cleanup](https://tonsofskills.com/plugins/code-cleanup), [web-analytics](https://tonsofskills.com/plugins/web-analytics), [token-optimizer](https://github.com/alexgreensh/token-optimizer), [executive-assistant-skills](https://tonsofskills.com/plugins/executive-assistant-skills), [skill-creator](https://tonsofskills.com/plugins/skill-creator), [cursor-pack](https://tonsofskills.com/plugins/cursor-pack), [crypto-portfolio-tracker](https://tonsofskills.com/plugins/crypto-portfolio-tracker). See all at [tonsofskills.com](https://tonsofskills.com).
+> Previous picks: [tonone](https://github.com/tonone-ai/tonone), [mnemos](https://github.com/polyxmedia/mnemos), [databricks-pack](https://tonsofskills.com/plugins/databricks-pack), [kobiton-automate](https://tonsofskills.com/plugins/kobiton-automate), [skyvern](https://github.com/Skyvern-AI/skyvern), [code-cleanup](https://tonsofskills.com/plugins/code-cleanup), [web-analytics](https://tonsofskills.com/plugins/web-analytics), [token-optimizer](https://github.com/alexgreensh/token-optimizer), [executive-assistant-skills](https://tonsofskills.com/plugins/executive-assistant-skills), [skill-creator](https://tonsofskills.com/plugins/skill-creator), [cursor-pack](https://tonsofskills.com/plugins/cursor-pack), [crypto-portfolio-tracker](https://tonsofskills.com/plugins/crypto-portfolio-tracker). See all at [tonsofskills.com](https://tonsofskills.com).
 
 <!-- KILLER-SKILL:END -->
 

--- a/marketplace/src/data/spotlights.json
+++ b/marketplace/src/data/spotlights.json
@@ -1,19 +1,32 @@
 {
-  "week": "2026-W28",
+  "week": "2026-W30",
   "title": "Killer Skill of the Week",
   "spotlight": {
-    "pluginSlug": "tonone",
-    "headline": "A 23-agent engineering and product team that ships from one session — two commands, zero meetings",
-    "whyKiller": "tonone turns Claude Code into a full delivery team: 23 specialist agents (architect, reviewers, product, QA and the rest of the org chart) coordinated through 125 skills, so one session runs discovery, build, review, and ship without you playing project manager between tools. The mirror featured here is the curated cut — every one of its 114 agent definitions verifies clean at the kernel-strict frontmatter floor in the latest inventory run, preserved by the marketplace's never-clobber freeze. MIT-licensed and actively developed upstream; a frontmatter sweep for the skill tier is offered upstream and the roster works as-is today.",
-    "author": "tonone-ai",
-    "authorGithub": "tonone-ai",
+    "pluginSlug": "no-ai-slop",
+    "headline": "Strip AI slop from any draft — named-pattern edits that keep the writer's real voice",
+    "whyKiller": "no-ai-slop does two jobs and refuses to fake a third. In Edit mode it makes the minimum effective edit — cutting throat-clearing, weak verbs, and abstract nouns while deliberately preserving the writer's cadence, bluntness, humor, and honest admissions, so a rough draft still sounds like the same person afterward. In Detect mode it names each AI-slop pattern it finds, quotes the offending line, and gives the fix in a few words — and pointedly does NOT score the draft or guess whether an AI wrote it. That restraint is the whole point: AI detectors guess; named patterns are evidence the reader can check. MIT-licensed, single focused skill, actively maintained by Peter Yang.",
+    "author": "Peter Yang",
+    "authorGithub": "petergyang",
     "grade": "A",
-    "skillCount": 125,
-    "category": "ai-agency",
-    "link": "https://github.com/tonone-ai/tonone",
-    "quote": "One session. Two commands. Full team. Zero meetings."
+    "skillCount": 1,
+    "category": "productivity",
+    "link": "https://github.com/petergyang/no-ai-slop",
+    "quote": "AI detectors guess. Named patterns are evidence the user can check."
   },
   "hallOfFame": [
+    {
+      "week": "2026-W28",
+      "pluginSlug": "tonone",
+      "headline": "A 23-agent engineering and product team that ships from one session — two commands, zero meetings",
+      "whyKiller": "tonone turns Claude Code into a full delivery team: 23 specialist agents (architect, reviewers, product, QA and the rest of the org chart) coordinated through 125 skills, so one session runs discovery, build, review, and ship without you playing project manager between tools. The mirror featured here is the curated cut — every one of its 114 agent definitions verifies clean at the kernel-strict frontmatter floor in the latest inventory run, preserved by the marketplace's never-clobber freeze. MIT-licensed and actively developed upstream; a frontmatter sweep for the skill tier is offered upstream and the roster works as-is today.",
+      "author": "tonone-ai",
+      "authorGithub": "tonone-ai",
+      "grade": "A",
+      "skillCount": 125,
+      "category": "ai-agency",
+      "link": "https://github.com/tonone-ai/tonone",
+      "quote": "One session. Two commands. Full team. Zero meetings."
+    },
     {
       "week": "2026-W28",
       "pluginSlug": "mnemos",
@@ -152,8 +165,8 @@
     }
   ],
   "meta": {
-    "version": "2.7.0",
-    "lastUpdated": "2026-07-10",
+    "version": "2.8.0",
+    "lastUpdated": "2026-07-22",
     "curatedBy": "Jeremy Longshore"
   }
 }


### PR DESCRIPTION
## What
Rotates the Killer Skill of the Week to **[petergyang/no-ai-slop](https://github.com/petergyang/no-ai-slop)** (2026-W30); moves the outgoing `tonone` entry into `hallOfFame`. Regenerates the README KILLER-SKILL block from `spotlights.json` (source of truth) via `scripts/promote-spotlight.mjs`.

## Why
Editorial pick (Jeremy). `no-ai-slop` is an MIT writing-editor skill (668★, actively maintained) with two disciplined modes: **Edit** (minimum effective edit, preserves the writer's real voice) and **Detect** (names each AI-slop pattern + quotes the line + gives the fix, and explicitly refuses to score or guess whether an AI wrote it — *"AI detectors guess; named patterns are evidence"*). On-theme for the marketplace's quality bar.

## Note for your review
- **The blurb (`headline`/`whyKiller`/`quote`) is editorial — your call.** Edit `spotlights.json` on this branch or tell me the wording and I'll amend. Nothing else here is opinionated.
- Spotlight `link` points to the upstream GitHub repo (same pattern as the outgoing `tonone` entry — the skill isn't vendored into the catalog). Say the word if you'd rather I also add it via `sources.yaml` (Path B) so it gets a marketplace detail page.

## Verification
`promote-spotlight.mjs` dry-run + real run clean; diff is only `spotlights.json` + the regenerated README block.

## Refs
Editorial rotation; no code/config change.

- Jeremy Longshore
intentsolutions.io