### PR TITLE
feat(ci): deterministic fork-safe CI failure-explainer (reuses j-rig CheckResult) [skip auto-bump]

### DIFF
--- a/.github/workflows/ci-failure-explainer.yml
+++ b/.github/workflows/ci-failure-explainer.yml
@@ -1,0 +1,177 @@
+name: CI Failure Explainer
+
+# Posts a DETERMINISTIC "why did CI fail + how to fix each check" comment on a
+# PR whose "Validate Plugins" run failed — so fork contributors get actionable
+# feedback instead of a wall of red. No LLM, no secrets, no fork-code checkout:
+# it reads the failed jobs' logs via the base GITHUB_TOKEN and runs the
+# base-authored scripts/ci-failure-explainer.mjs. Advisory only — this workflow
+# is NOT in the ci-required aggregate and can never block a merge.
+#
+# FORK-SAFE via `workflow_run`: it runs in BASE context (base workflow file,
+# base token) regardless of whether the triggering PR is a fork, which is why
+# it can comment on fork PRs at all. See the audit must-fixes encoded below
+# (spoof-proof PR resolution, event/conclusion gates, least privilege).
+
+on:
+  workflow_run:
+    workflows: ['Validate Plugins']
+    types: [completed]
+  # Manual hook to test the whole pipeline against a KNOWN historical failed
+  # run (e.g. #1101's Validate Plugins run) — workflow_run lanes only execute
+  # the copy on the default branch, so this is the only way to exercise it
+  # before trusting it on live PRs.
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'A failed "Validate Plugins" run id to explain (for testing)'
+        type: string
+        required: true
+
+concurrency:
+  # PR number isn't known at trigger time (workflow_run), so key on the head
+  # branch + head repo (both present on the payload) — dedupes a force-push
+  # storm to one live run per PR head.
+  group: >-
+    ci-failure-explainer-${{ github.event.workflow_run.head_repository.full_name
+    || github.repository }}-${{ github.event.workflow_run.head_branch
+    || inputs.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  actions: read # read the failed run's jobs + their logs
+  checks: read
+  pull-requests: write # upsert the one marker comment
+
+jobs:
+  explain:
+    runs-on: ubuntu-latest
+    # Only for genuinely-failed PR-triggered runs (skip pushes to main,
+    # successes, and in-progress). workflow_dispatch always proceeds.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (vars.ENABLE_CI_FAILURE_EXPLAINER == 'true' &&
+       github.event.workflow_run.event == 'pull_request' &&
+       github.event.workflow_run.conclusion == 'failure')
+    steps:
+      # Base repo only — we run scripts/ci-failure-explainer.mjs from main,
+      # never any fork content.
+      - name: Checkout base (script source)
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Resolve the run + PR (spoof-proof)
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            RUN_ID="${{ inputs.run_id }}"
+            RUN=$(gh api "repos/$REPO/actions/runs/$RUN_ID")
+            HEAD_SHA=$(echo "$RUN" | jq -r '.head_sha')
+            HEAD_REPO=$(echo "$RUN" | jq -r '.head_repository.full_name')
+          else
+            RUN_ID="${{ github.event.workflow_run.id }}"
+            HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
+            HEAD_REPO="${{ github.event.workflow_run.head_repository.full_name }}"
+          fi
+
+          # workflow_run.pull_requests[] is EMPTY for fork PRs — resolve via the
+          # commit→PRs association against the BASE repo, then VERIFY the match.
+          CANDIDATES=$(gh api "repos/$REPO/commits/$HEAD_SHA/pulls" \
+            --jq '[.[] | {number, head_sha: .head.sha, head_repo: .head.repo.full_name, state}]')
+          PR_NUMBER=$(echo "$CANDIDATES" | jq -r \
+            --arg sha "$HEAD_SHA" --arg repo "$HEAD_REPO" \
+            'map(select(.head_sha == $sha and .head_repo == $repo and .state == "open")) | (.[0].number // empty)')
+
+          if [ -z "${PR_NUMBER:-}" ]; then
+            echo "::notice::No open PR matches head_sha=$HEAD_SHA head_repo=$HEAD_REPO — refusing to comment (anti-spoof)."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Belt-and-suspenders: re-fetch the resolved PR and confirm BOTH the
+          # head SHA and head repo still equal the run's — never post otherwise.
+          PR=$(gh api "repos/$REPO/pulls/$PR_NUMBER")
+          if [ "$(echo "$PR" | jq -r '.head.sha')" != "$HEAD_SHA" ] || \
+             [ "$(echo "$PR" | jq -r '.head.repo.full_name')" != "$HEAD_REPO" ]; then
+            echo "::notice::Resolved PR #$PR_NUMBER no longer matches the run head — refusing to comment."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          {
+            echo "skip=false"
+            echo "run_id=$RUN_ID"
+            echo "pr_number=$PR_NUMBER"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Gather failed checks (name + bounded error text)
+        id: gather
+        if: steps.resolve.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ steps.resolve.outputs.run_id }}
+        run: |
+          set -euo pipefail
+          # Failed jobs of the Validate Plugins run (base repo → base token).
+          gh api --paginate "repos/$REPO/actions/runs/$RUN_ID/jobs" \
+            > /tmp/jobs.json
+          jq -c '[.jobs[] | select(.conclusion=="failure") | {name, id, url: .html_url}]' \
+            /tmp/jobs.json > /tmp/failed-jobs.json
+          COUNT=$(jq 'length' /tmp/failed-jobs.json)
+          echo "failed jobs: $COUNT" >&2
+
+          # For each failed job, pull its log and keep only signature-bearing
+          # lines, hard-capped. The log is base-repo CI output; we never execute
+          # it, only pattern-match it in the explainer.
+          echo '[]' > /tmp/failed-checks.json
+          for row in $(jq -c '.[]' /tmp/failed-jobs.json); do
+            JID=$(echo "$row" | jq -r '.id')
+            NAME=$(echo "$row" | jq -r '.name')
+            URL=$(echo "$row" | jq -r '.url')
+            LOG=$(gh api "repos/$REPO/actions/jobs/$JID/logs" 2>/dev/null || true)
+            # Keep only lines carrying a known signature; cap to 4000 bytes.
+            TEXT=$(printf '%s' "$LOG" \
+              | grep -aiE 'ERR_PNPM_OUTDATED_LOCKFILE|MD[0-9]{3}|MISSING required document|error|not formatted|::error' \
+              | head -c 4000 || true)
+            jq --arg n "$NAME" --arg t "$TEXT" --arg u "$URL" \
+              '. += [{name:$n, text:$t, url:$u}]' /tmp/failed-checks.json \
+              > /tmp/failed-checks.json.tmp && mv /tmp/failed-checks.json.tmp /tmp/failed-checks.json
+          done
+          echo "have=$( [ "$COUNT" -gt 0 ] && echo true || echo false )" >> "$GITHUB_OUTPUT"
+
+      - name: Render the deterministic explanation
+        id: render
+        if: steps.resolve.outputs.skip == 'false' && steps.gather.outputs.have == 'true'
+        run: |
+          set -euo pipefail
+          node scripts/ci-failure-explainer.mjs --checks /tmp/failed-checks.json \
+            > /tmp/comment.md
+          echo "rendered comment ($(wc -c < /tmp/comment.md) bytes):" >&2
+          cat /tmp/comment.md >&2
+
+      - name: Upsert the marker comment (idempotent)
+        if: steps.resolve.outputs.skip == 'false' && steps.gather.outputs.have == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          MARKER='<!-- ci-failure-explainer -->'
+          # Find an existing comment carrying our marker; PATCH it, else create.
+          CID=$(gh api --paginate "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --jq "map(select(.body | contains(\"$MARKER\"))) | (.[0].id // empty)")
+          if [ -n "${CID:-}" ]; then
+            gh api -X PATCH "repos/$REPO/issues/comments/$CID" \
+              -F body=@/tmp/comment.md >/dev/null
+            echo "updated comment $CID on PR #$PR_NUMBER"
+          else
+            gh api -X POST "repos/$REPO/issues/$PR_NUMBER/comments" \
+              -F body=@/tmp/comment.md >/dev/null
+            echo "created comment on PR #$PR_NUMBER"
+          fi

--- a/scripts/ci-failure-explainer.mjs
+++ b/scripts/ci-failure-explainer.mjs
@@ -1,0 +1,287 @@
+#!/usr/bin/env node
+/**
+ * ci-failure-explainer.mjs
+ *
+ * DETERMINISTIC "why did CI fail + how to fix it" renderer for a contributor
+ * PR comment. Given a set of FAILED CI checks (check-run name + its error
+ * text), it emits a marker-anchored markdown comment mapping each recognised
+ * failure signature to a concrete, repo-specific fix. NO LLM, no network, no
+ * fork-code execution — a pure function of its input, so the same failures
+ * always render byte-identical output.
+ *
+ * WHY THIS SHAPE (reuse, not reinvent): this deliberately reuses the mechanism
+ * from @intentsolutions/jrig-cli (`@j-rig/core`):
+ *   - the `CheckResult { id, severity, message, details }` finding record,
+ *     where `details` is the "how to fix" slot
+ *     (j-rig-binary-eval/packages/core/src/checks/types.ts),
+ *   - the `summarize()` + report-formatting pattern (same file), and
+ *   - the rollout-gate marker-pair idempotent-comment model
+ *     (`<!-- key --> … <!-- /key -->`, patch-in-place, byte-stable —
+ *     j-rig-binary-eval/packages/pr-comment/src/render.ts).
+ * The SIGNATURE_CATALOG below is the `{code → handler}` dispatch pattern from
+ * j-rig's intentional-mapping registry, keyed on THIS repo's CI signatures.
+ *
+ * The catalog is authored (there is no upstream signature→fix table to copy);
+ * everything around it is the reused j-rig contract.
+ *
+ * Usage:
+ *   node scripts/ci-failure-explainer.mjs --checks failed-checks.json
+ *   node scripts/ci-failure-explainer.mjs --checks failed-checks.json --json
+ *   cat failed-checks.json | node scripts/ci-failure-explainer.mjs --stdin
+ *
+ * Input JSON shape (array of failed checks):
+ *   [ { "name": "eslint-check", "text": "…first ~N lines of the failing log…",
+ *       "url": "https://github.com/…/job/123" }, … ]
+ *
+ * Output: markdown comment on stdout (or the PackageReport JSON with --json).
+ * Exit code: always 0 — this is an advisory helper; producing no recognised
+ * findings still emits a valid (generic) comment.
+ */
+
+import { readFileSync } from 'node:fs';
+
+// The idempotence marker key. The workflow lists PR comments, finds the one
+// carrying the OPENING marker for this key, and PATCHes it in place instead of
+// posting a duplicate. Deliberately DISTINCT from pr-prescreen's
+// `pr-prescreen-marker` so the two bots never clobber each other's comment.
+export const MARKER_KEY = 'ci-failure-explainer';
+export const MARKER_OPEN = `<!-- ${MARKER_KEY} -->`;
+export const MARKER_CLOSE = `<!-- /${MARKER_KEY} -->`;
+
+// ---------------------------------------------------------------------------
+// j-rig CheckResult contract (reused shape)
+// ---------------------------------------------------------------------------
+
+/** @typedef {{ id: string, description?: string, severity: 'error'|'warning'|'pass', message: string, details?: string }} CheckResult */
+
+/** Build the summary counts — mirrors @j-rig/core summarize(). */
+export function summarize(results) {
+  return {
+    total: results.length,
+    passed: results.filter((r) => r.severity === 'pass').length,
+    warnings: results.filter((r) => r.severity === 'warning').length,
+    errors: results.filter((r) => r.severity === 'error').length,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// SIGNATURE CATALOG — the {signature → CheckResult} dispatch (MM-N pattern)
+//
+// Each entry: appliesTo(name, text) returns a truthy match (or null); toResult
+// turns that match into a CheckResult whose `details` is the concrete fix. The
+// FIRST matching entry per failed check wins (order = specificity). A check
+// that matches nothing falls through to the generic explainer so a contributor
+// always gets *something* actionable plus the log link.
+// ---------------------------------------------------------------------------
+
+/** Extract distinct markdownlint rule codes (MD012, MD022, …) from log text. */
+function markdownRules(text) {
+  const codes = new Set();
+  for (const m of text.matchAll(/\bMD\d{3}\b/g)) codes.add(m[0]);
+  return [...codes].sort();
+}
+
+/** Extract the "MISSING required document: <path>" targets from log text. */
+function missingDocs(text) {
+  const docs = new Set();
+  for (const m of text.matchAll(/MISSING required document:\s*(\S+)/g)) docs.add(m[1]);
+  return [...docs].sort();
+}
+
+export const SIGNATURE_CATALOG = [
+  {
+    id: 'deps:lockfile-stale',
+    appliesTo: (_name, text) => /ERR_PNPM_OUTDATED_LOCKFILE/.test(text),
+    toResult: () => ({
+      id: 'deps:lockfile-stale',
+      severity: 'error',
+      message:
+        'pnpm-lock.yaml is out of date with a changed package.json (frozen-lockfile install failed).',
+      details:
+        'Run `pnpm install --lockfile-only` locally, then commit the updated `pnpm-lock.yaml`. ' +
+        'Do NOT hand-edit the lockfile. This one fix typically clears eslint-check AND cli-smoke-tests, ' +
+        'which both fail early when dependencies cannot install.',
+    }),
+  },
+  {
+    id: 'docs:submission-missing',
+    appliesTo: (_name, text) => /MISSING required document/.test(text),
+    toResult: (_m, text) => {
+      const docs = missingDocs(text);
+      return {
+        id: 'docs:submission-missing',
+        severity: 'error',
+        message:
+          docs.length > 0
+            ? `New plugin is missing required submission doc(s): ${docs.join(', ')}.`
+            : 'New plugin is missing required submission documents for its tier.',
+        details:
+          'Add the tier-required docs (micro → `docs/PRD.md`; standard → + `docs/ADR.md`; ' +
+          'pack → + `docs/ONE-PAGER.md`). Templates live in `templates/skill-docs/`; the tier ' +
+          'matrix + standard are in `000-docs/700-DR-GUID-skill-submission-standard.md`.',
+      };
+    },
+  },
+  {
+    id: 'docs:markdownlint',
+    appliesTo: (name, text) => /markdownlint/i.test(name) || markdownRules(text).length > 0,
+    toResult: (_m, text) => {
+      const rules = markdownRules(text);
+      return {
+        id: 'docs:markdownlint',
+        severity: 'error',
+        message:
+          rules.length > 0
+            ? `Markdown style violations: ${rules.join(', ')}.`
+            : 'Markdown style violations (markdownlint).',
+        details:
+          'Fix the flagged lines (common ones: MD022 blank lines around headings, MD032 blank ' +
+          'lines around lists, MD012 no consecutive blanks, MD047 end file with one newline). ' +
+          'Run `npx markdownlint-cli2 "<your-changed-file>.md"` locally to see + fix them.',
+      };
+    },
+  },
+  {
+    id: 'style:prettier',
+    appliesTo: (name) => /format-check/i.test(name),
+    toResult: () => ({
+      id: 'style:prettier',
+      severity: 'error',
+      message: 'Files are not Prettier-formatted (format-check).',
+      details: 'Run `pnpm run format` and commit the result.',
+    }),
+  },
+  {
+    id: 'lint:eslint',
+    appliesTo: (name) => /eslint/i.test(name),
+    toResult: () => ({
+      id: 'lint:eslint',
+      severity: 'error',
+      message: 'ESLint reported problems (eslint-check).',
+      details:
+        'Run `pnpm lint` locally to see them. If the log shows ERR_PNPM_OUTDATED_LOCKFILE, ' +
+        'fix the lockfile first (see the lockfile item) — eslint fails early when deps cannot install.',
+    }),
+  },
+  {
+    id: 'validate:marketplace',
+    appliesTo: (name, text) => /^validate$/i.test(name) || /validate-skills-schema/.test(text),
+    toResult: () => ({
+      id: 'validate:marketplace',
+      severity: 'error',
+      message: 'A SKILL.md / plugin.json failed the marketplace-tier validator.',
+      details:
+        'Run `python3 scripts/validate-skills-schema.py --marketplace <your-plugin-dir>` locally. ' +
+        'The 8 required frontmatter fields (name, description, allowed-tools, version, author, ' +
+        'license, compatibility, tags) plus the required body sections must all be present.',
+    }),
+  },
+];
+
+/**
+ * Turn a list of failed checks into a j-rig-shaped PackageReport.
+ * @param {{name: string, text?: string, url?: string}[]} failedChecks
+ * @param {string} nowIso  timestamp (injected so the function stays pure/testable)
+ */
+export function explain(failedChecks, nowIso) {
+  /** @type {CheckResult[]} */
+  const results = [];
+  for (const check of failedChecks) {
+    const name = check.name ?? '(unknown check)';
+    const text = check.text ?? '';
+    const entry = SIGNATURE_CATALOG.find((e) => e.appliesTo(name, text));
+    if (entry) {
+      results.push(entry.toResult(name, text));
+    } else {
+      // Generic fallback — never leave a failed check unexplained.
+      results.push({
+        id: `check:${name}`,
+        severity: 'error',
+        message: `\`${name}\` failed.`,
+        details: check.url
+          ? `Open the check log for the specific error: ${check.url}`
+          : 'Open the failing check’s log for the specific error.',
+      });
+    }
+  }
+  // De-dupe by id (e.g. eslint + cli-smoke both trace to the lockfile) so the
+  // contributor sees each fix once.
+  const seen = new Set();
+  const deduped = results.filter((r) => (seen.has(r.id) ? false : seen.add(r.id)));
+  return {
+    skill_name: null,
+    timestamp: nowIso,
+    results: deduped,
+    summary: summarize(deduped),
+  };
+}
+
+/**
+ * Render the report as a marker-anchored markdown PR comment (reuses the
+ * rollout-gate idempotence model — the workflow patches the comment carrying
+ * MARKER_OPEN in place). Pure: same report → byte-identical body.
+ */
+export function renderComment(report) {
+  const lines = [];
+  lines.push(MARKER_OPEN);
+  lines.push('## Why this PR’s checks failed — and how to fix each one');
+  lines.push('');
+  lines.push(
+    '_Deterministic summary from the failing checks. Advisory, not a required gate; ' +
+      'fix these and push to re-run._',
+  );
+  lines.push('');
+  if (report.results.length === 0) {
+    lines.push('No recognised failures to explain — open the checks tab for details.');
+  } else {
+    for (const r of report.results) {
+      lines.push(`### \`${r.id}\``);
+      lines.push(`**${r.message}**`);
+      if (r.details) {
+        lines.push('');
+        lines.push(r.details);
+      }
+      lines.push('');
+    }
+  }
+  lines.push(MARKER_CLOSE);
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function main() {
+  const args = process.argv.slice(2);
+  const asJson = args.includes('--json');
+  const useStdin = args.includes('--stdin');
+  const checksIdx = args.indexOf('--checks');
+  let raw;
+  if (useStdin) {
+    raw = readFileSync(0, 'utf-8');
+  } else if (checksIdx !== -1 && args[checksIdx + 1]) {
+    raw = readFileSync(args[checksIdx + 1], 'utf-8');
+  } else {
+    console.error('Usage: ci-failure-explainer.mjs --checks <file.json> | --stdin  [--json]');
+    process.exit(2);
+  }
+  let failedChecks;
+  try {
+    failedChecks = JSON.parse(raw);
+    if (!Array.isArray(failedChecks)) throw new Error('input must be a JSON array');
+  } catch (e) {
+    console.error(`ci-failure-explainer: bad input JSON: ${e.message}`);
+    process.exit(2);
+  }
+  // Timestamp is stamped by the CLI (impure boundary), never inside explain().
+  const report = explain(failedChecks, new Date().toISOString());
+  process.stdout.write(asJson ? JSON.stringify(report, null, 2) : renderComment(report));
+  process.stdout.write('\n');
+}
+
+// Only run main() when invoked directly, so tests can import the pure fns.
+import { fileURLToPath } from 'node:url';
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main();
+}

--- a/scripts/ci-failure-explainer.test.mjs
+++ b/scripts/ci-failure-explainer.test.mjs
@@ -1,0 +1,129 @@
+/**
+ * ci-failure-explainer.test.mjs
+ *
+ * Locks the deterministic CI-failure → contributor-fix catalog and the
+ * marker-anchored, byte-stable comment renderer. Run:
+ *   node --test scripts/ci-failure-explainer.test.mjs
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  explain,
+  renderComment,
+  summarize,
+  SIGNATURE_CATALOG,
+  MARKER_OPEN,
+  MARKER_CLOSE,
+} from './ci-failure-explainer.mjs';
+
+const TS = '2026-07-22T00:00:00.000Z'; // fixed — explain() is pure given a timestamp
+
+const idsFor = (checks) => explain(checks, TS).results.map((r) => r.id);
+
+test('ERR_PNPM_OUTDATED_LOCKFILE → deps:lockfile-stale with the lockfile-only fix', () => {
+  const r = explain(
+    [{ name: 'eslint-check', text: 'ERR_PNPM_OUTDATED_LOCKFILE Cannot install' }],
+    TS,
+  ).results;
+  assert.equal(r.length, 1);
+  assert.equal(r[0].id, 'deps:lockfile-stale');
+  assert.equal(r[0].severity, 'error');
+  assert.match(r[0].details, /pnpm install --lockfile-only/);
+});
+
+test('markdownlint rule codes are extracted into the message', () => {
+  const text = 'README.md:125 MD032/blanks-around-lists\nSKILL.md:5 MD022/blanks-around-headings';
+  const r = explain([{ name: 'markdownlint', text }], TS).results;
+  assert.equal(r[0].id, 'docs:markdownlint');
+  assert.match(r[0].message, /MD022/);
+  assert.match(r[0].message, /MD032/);
+});
+
+test('MISSING required document → docs:submission-missing naming the docs', () => {
+  const text =
+    'MISSING required document: plugins/mcp/x/docs/PRD.md\nMISSING required document: plugins/mcp/x/docs/ADR.md';
+  const r = explain([{ name: 'check-submission-docs', text }], TS).results;
+  assert.equal(r[0].id, 'docs:submission-missing');
+  assert.match(r[0].message, /PRD\.md/);
+  assert.match(r[0].message, /ADR\.md/);
+  assert.match(r[0].details, /templates\/skill-docs/);
+});
+
+test('format-check → style:prettier; standalone eslint → lint:eslint', () => {
+  assert.deepEqual(idsFor([{ name: 'format-check', text: 'not formatted' }]), ['style:prettier']);
+  assert.deepEqual(idsFor([{ name: 'eslint-check', text: 'some eslint problem' }]), [
+    'lint:eslint',
+  ]);
+});
+
+test('validate check → validate:marketplace', () => {
+  assert.deepEqual(idsFor([{ name: 'validate', text: 'exit code 1' }]), ['validate:marketplace']);
+  assert.deepEqual(idsFor([{ name: 'x', text: 'validate-skills-schema.py ERROR' }]), [
+    'validate:marketplace',
+  ]);
+});
+
+test('unknown check falls through to a generic explanation with the log link', () => {
+  const r = explain([{ name: 'mystery-gate', text: 'weird', url: 'https://gh/job/9' }], TS).results;
+  assert.equal(r[0].id, 'check:mystery-gate');
+  assert.match(r[0].details, /https:\/\/gh\/job\/9/);
+});
+
+test('duplicate signatures de-dupe by id (lockfile hit by two checks → one result)', () => {
+  const r = explain(
+    [
+      { name: 'eslint-check', text: 'ERR_PNPM_OUTDATED_LOCKFILE' },
+      { name: 'cli-smoke-tests', text: 'ERR_PNPM_OUTDATED_LOCKFILE' },
+    ],
+    TS,
+  ).results;
+  assert.equal(r.length, 1);
+  assert.equal(r[0].id, 'deps:lockfile-stale');
+});
+
+test('the real #1101 failure set produces the expected distinct fixes', () => {
+  const ids = idsFor([
+    { name: 'eslint-check', text: 'ERR_PNPM_OUTDATED_LOCKFILE' },
+    { name: 'cli-smoke-tests', text: 'ERR_PNPM_OUTDATED_LOCKFILE' },
+    { name: 'markdownlint', text: 'MD022 MD032 MD047' },
+    { name: 'check-submission-docs', text: 'MISSING required document: docs/PRD.md' },
+    { name: 'validate', text: 'exit code 1' },
+  ]);
+  assert.deepEqual(
+    new Set(ids),
+    new Set([
+      'deps:lockfile-stale',
+      'docs:markdownlint',
+      'docs:submission-missing',
+      'validate:marketplace',
+    ]),
+  );
+});
+
+test('renderComment is marker-wrapped and byte-stable for the same input', () => {
+  const checks = [{ name: 'markdownlint', text: 'MD022' }];
+  const a = renderComment(explain(checks, TS));
+  const b = renderComment(explain(checks, TS));
+  assert.equal(a, b, 'same report must render byte-identical');
+  assert.ok(a.startsWith(MARKER_OPEN), 'opens with the idempotence marker');
+  assert.ok(a.trimEnd().endsWith(MARKER_CLOSE), 'closes with the marker');
+  assert.match(a, /MD022/);
+});
+
+test('summarize counts severities', () => {
+  const s = summarize([{ severity: 'error' }, { severity: 'error' }, { severity: 'pass' }]);
+  assert.deepEqual(s, { total: 3, passed: 1, warnings: 0, errors: 2 });
+});
+
+test('every catalog entry has an id, appliesTo, and toResult returning a CheckResult', () => {
+  for (const e of SIGNATURE_CATALOG) {
+    assert.equal(typeof e.id, 'string');
+    assert.equal(typeof e.appliesTo, 'function');
+    const res = e.toResult('x', 'MD001 ERR_PNPM_OUTDATED_LOCKFILE MISSING required document: a/b');
+    assert.equal(typeof res.id, 'string');
+    assert.ok(['error', 'warning', 'pass'].includes(res.severity));
+    assert.equal(typeof res.message, 'string');
+  }
+});


### PR DESCRIPTION
> **For your review — do NOT auto-merge.** Ships **default-OFF** (`vars.ENABLE_CI_FAILURE_EXPLAINER` unset), so nothing changes on live PRs until you flip it on after review + a live test (below).

## What
A **deterministic, fork-safe "why did CI fail + how to fix each check" commenter.** When a PR's *Validate Plugins* run fails, it posts one contributor-facing comment naming each failed gate and its exact fix. No LLM, no secrets, no fork-code checkout.

## Why + decision rationale
Fork PRs (e.g. #1101) get a wall of red with no explanation: the MiniMax lanes withhold `MINIMAX_API_KEY` from forks (correctly), and prescreen only grades plugin/SKILL validation — **not** the generic gates that actually block (stale lockfile, markdownlint, missing submission docs). This fills that gap. *Chose an authored catalog on the j-rig schema over an LLM because these failures are finite deterministic signatures — zero cost, zero hallucination, and zero prompt-injection surface (the exact risk the plan audit flagged, and on-theme for the "no AI slop" bar). The MiniMax phrasing layer is deferred to a fast-follow (your Option 3).*

## Reuses your mechanism (not reinvented)
Per your steer, this reuses the **j-rig / intent-audit** deterministic machinery rather than hand-rolling:
- the `CheckResult { id, severity, message, details }` finding record — `details` is the fix slot — and `summarize()` (`@j-rig/core` `checks/types.ts`),
- the rollout-gate **marker-pair idempotent comment** model (`<!-- ci-failure-explainer --> … <!-- /… -->`, patch-in-place, byte-stable — `@j-rig/pr-comment` `render.ts`),
- the `{code → handler}` **dispatch** pattern from j-rig's intentional-mapping registry, here `SIGNATURE_CATALOG` keyed on this repo's CI signatures.
The explorer confirmed there is **no upstream signature→fix table to copy** — so the catalog text is authored; the schema, renderer, and dispatch are yours.

## How it works
- `scripts/ci-failure-explainer.mjs` — pure engine: `explain(failedChecks, ts)` → j-rig `PackageReport`; `renderComment(report)` → marker-wrapped markdown. Signatures covered: `ERR_PNPM_OUTDATED_LOCKFILE`, markdownlint `MDxxx` (codes extracted), `MISSING required document` (docs named), `format-check`, `eslint`, the marketplace validator; unknown checks → generic explanation + log link; results de-dupe by id (eslint + cli-smoke both trace to the lockfile → one fix).
- `.github/workflows/ci-failure-explainer.yml` — `workflow_run` lane on *Validate Plugins* completion, runs in BASE context, reads the failed jobs' logs via the base token, runs the base script, upserts the one marker comment.

## Layer(s) touched
CI only + one new self-contained script/test. **Not** wired into `validate-plugins.yml`'s `ci-required` `needs:` — structurally advisory, can never block a merge.

## Security (from the 4-reviewer plan audit)
- **C-1 spoof-proof PR resolution:** `workflow_run.pull_requests[]` is empty for fork PRs, so resolve via `commits/{head_sha}/pulls` and **verify** the resolved PR's `head.sha` AND `head.repo.full_name` equal the run's before commenting; refuse on any mismatch (blocks the confused-deputy → victim-PR write).
- **No prompt-injection surface:** output is authored deterministic text, not LLM output derived from attacker content.
- Gated to `event==pull_request && conclusion==failure`; **kill switch default OFF**; least-privilege perms (`pull-requests:write`, `actions/checks/contents:read`; no `id-token`/`packages`/MiniMax key); concurrency keyed on head_repo+head_branch, cancel-in-progress; log text capped 4 KB.

## Verification & evidence
- `node --test scripts/ci-failure-explainer.test.mjs` → **11/11** (each signature → expected fix; the real #1101 set → 4 distinct fixes; byte-stable marker render; de-dup). `actionlint` clean; prettier clean.
- Live-render of the #1101 failure set produced the exact lockfile / markdownlint / missing-docs / validate comment (in the commit body).

## How to validate before enabling (built-in test hook)
`workflow_run` lanes only run the default-branch copy, so there's a `workflow_dispatch` input: after merge, run this workflow with `run_id = <#1101's failed Validate Plugins run>` to exercise resolve→log-fetch→render→comment against a real fork PR. Then set `vars.ENABLE_CI_FAILURE_EXPLAINER=true` to go live.

## Risk / rollback
Advisory, default-off. Rollback = unset the var (instant) or revert this branch. No deps, no migrations, no secrets added.

## Follow-up
- MiniMax phrasing layer (your Option 3 fast-follow), grounded on these same signatures + the audit's output-sanitization must-fixes.
- Part B (restore prescreen's plugin-grade comment on fork PRs) is separable and **not** needed for this — the explainer reads CI output, never fork files.

## Refs
Plan audit: 4 maintainer reviewers (security / CI-correctness / simplicity / correctness). Relates to #1101.

- Jeremy Longshore
intentsolutions.io
