### PR TITLE
fix(plugins): clear every conform advisory and close the escape-scan fail-open

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@commitlint/cli": "^20.5.3",
     "@commitlint/config-conventional": "^20.5.3",
     "@eslint/js": "^9.39.4",
-    "@intentsolutions/audit-harness": "^1.1.5",
+    "@intentsolutions/audit-harness": "^1.3.1",
     "@intentsolutions/core": "0.9.0",
     "@intentsolutions/jrig-cli": "0.1.2",
     "@types/node": "^20.19.41",

--- a/plugins/community/walkie-talkie/SKILL.md
+++ b/plugins/community/walkie-talkie/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: walkie-talkie
-description: Use when two or more agent sessions — same or different platforms (Claude Code, Codex, Gemini CLI, Copilot, Cursor) — work the same repo concurrently, hand off in-flight work, or need to interrogate each other about a handoff. Triggers: "set up comms with the other session", "hand this off to Codex/Gemini", "grill the handoff", "check the mailbox", parallel sessions clobbering shared files, resuming work another agent left half-done.
+description: 'Use when two or more agent sessions — same or different platforms (Claude Code, Codex, Gemini CLI, Copilot, Cursor) — work the same repo concurrently, hand off in-flight work, or need to interrogate each other about a handoff. Triggers: "set up comms with the other session", "hand this off to Codex/Gemini", "grill the handoff", "check the mailbox", parallel sessions clobbering shared files, resuming work another agent left half-done.'
 ---
 
 # Walkie-Talkie

--- a/plugins/productivity/pm-ai-partner/skills/builder/SKILL.md
+++ b/plugins/productivity/pm-ai-partner/skills/builder/SKILL.md
@@ -9,8 +9,7 @@ version: 1.8.0
 author: Ahmed Khaled Mohamed <ahmd.khaled.a.mohamed@gmail.com>
 license: MIT
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(npm:*), Bash(node:*)
-argument-hint:
-- what to build
+argument-hint: "what to build"
 tags:
 - productivity
 - dashboard

--- a/plugins/productivity/pm-ai-partner/skills/competitor-analyst/SKILL.md
+++ b/plugins/productivity/pm-ai-partner/skills/competitor-analyst/SKILL.md
@@ -9,8 +9,7 @@ version: 1.8.0
 author: Ahmed Khaled Mohamed <ahmd.khaled.a.mohamed@gmail.com>
 license: MIT
 allowed-tools: Read, Glob, Grep
-argument-hint:
-- competitor or market
+argument-hint: "competitor or market"
 tags:
 - productivity
 - competitor-analyst

--- a/plugins/productivity/pm-ai-partner/skills/data-analyst/SKILL.md
+++ b/plugins/productivity/pm-ai-partner/skills/data-analyst/SKILL.md
@@ -9,8 +9,7 @@ version: 1.8.0
 author: Ahmed Khaled Mohamed <ahmd.khaled.a.mohamed@gmail.com>
 license: MIT
 allowed-tools: Read, Grep, Glob, Bash(npm:*), Bash(node:*)
-argument-hint:
-- metric or question
+argument-hint: "metric or question"
 tags:
 - productivity
 - database

--- a/plugins/productivity/pm-ai-partner/skills/devil-advocate/SKILL.md
+++ b/plugins/productivity/pm-ai-partner/skills/devil-advocate/SKILL.md
@@ -9,8 +9,7 @@ version: 1.8.0
 author: Ahmed Khaled Mohamed <ahmd.khaled.a.mohamed@gmail.com>
 license: MIT
 allowed-tools: Read, Glob, Grep
-argument-hint:
-- idea or proposal to challenge
+argument-hint: "idea or proposal to challenge"
 tags:
 - productivity
 - testing

--- a/plugins/productivity/pm-ai-partner/skills/hypothesis-tester/SKILL.md
+++ b/plugins/productivity/pm-ai-partner/skills/hypothesis-tester/SKILL.md
@@ -9,8 +9,7 @@ version: 1.8.0
 author: Ahmed Khaled Mohamed <ahmd.khaled.a.mohamed@gmail.com>
 license: MIT
 allowed-tools: Read, Glob, Grep
-argument-hint:
-- assumption or experiment
+argument-hint: "assumption or experiment"
 tags:
 - productivity
 - testing

--- a/plugins/productivity/pm-ai-partner/skills/meeting-prep/SKILL.md
+++ b/plugins/productivity/pm-ai-partner/skills/meeting-prep/SKILL.md
@@ -9,8 +9,7 @@ version: 1.8.0
 author: Ahmed Khaled Mohamed <ahmd.khaled.a.mohamed@gmail.com>
 license: MIT
 allowed-tools: Read, Glob, Grep
-argument-hint:
-- meeting topic or attendee
+argument-hint: "meeting topic or attendee"
 tags:
 - productivity
 - meeting-prep

--- a/plugins/productivity/pm-ai-partner/skills/product-brief/SKILL.md
+++ b/plugins/productivity/pm-ai-partner/skills/product-brief/SKILL.md
@@ -8,8 +8,7 @@ version: 1.8.0
 author: Ahmed Khaled Mohamed <ahmd.khaled.a.mohamed@gmail.com>
 license: MIT
 allowed-tools: Read, Glob, Grep
-argument-hint:
-- feature name
+argument-hint: "feature name"
 tags:
 - productivity
 - product-brief

--- a/plugins/productivity/pm-ai-partner/skills/stakeholder-update/SKILL.md
+++ b/plugins/productivity/pm-ai-partner/skills/stakeholder-update/SKILL.md
@@ -9,8 +9,7 @@ version: 1.8.0
 author: Ahmed Khaled Mohamed <ahmd.khaled.a.mohamed@gmail.com>
 license: MIT
 allowed-tools: Read, Glob, Grep
-argument-hint:
-- project or team
+argument-hint: "project or team"
 tags:
 - productivity
 - stakeholder-update

--- a/plugins/productivity/pm-ai-partner/skills/strategic-clarity/SKILL.md
+++ b/plugins/productivity/pm-ai-partner/skills/strategic-clarity/SKILL.md
@@ -9,8 +9,7 @@ version: 1.8.0
 author: Ahmed Khaled Mohamed <ahmd.khaled.a.mohamed@gmail.com>
 license: MIT
 allowed-tools: Read, Glob, Grep
-argument-hint:
-- phase: absorb/audit/articulate/align
+argument-hint: "phase: absorb/audit/articulate/align"
 tags:
 - productivity
 - workflow

--- a/plugins/productivity/pm-ai-partner/skills/technical-analyst/SKILL.md
+++ b/plugins/productivity/pm-ai-partner/skills/technical-analyst/SKILL.md
@@ -9,10 +9,7 @@ version: 1.8.0
 author: Ahmed Khaled Mohamed <ahmd.khaled.a.mohamed@gmail.com>
 license: MIT
 allowed-tools: Read, Grep, Glob, Bash(git:*)
-argument-hint:
-- system
-- service
-- or file
+argument-hint: "system service or file"
 tags:
 - productivity
 - technical-analyst

--- a/plugins/productivity/pm-ai-partner/skills/thought-partner/SKILL.md
+++ b/plugins/productivity/pm-ai-partner/skills/thought-partner/SKILL.md
@@ -8,8 +8,7 @@ version: 1.8.0
 author: Ahmed Khaled Mohamed <ahmd.khaled.a.mohamed@gmail.com>
 license: MIT
 allowed-tools: Read, Glob, Grep
-argument-hint:
-- topic or question
+argument-hint: "topic or question"
 tags:
 - productivity
 - thought-partner

--- a/plugins/productivity/pm-ai-partner/skills/writer/SKILL.md
+++ b/plugins/productivity/pm-ai-partner/skills/writer/SKILL.md
@@ -8,8 +8,7 @@ version: 1.8.0
 author: Ahmed Khaled Mohamed <ahmd.khaled.a.mohamed@gmail.com>
 license: MIT
 allowed-tools: Read, Glob, Grep
-argument-hint:
-- document type or topic
+argument-hint: "document type or topic"
 tags:
 - productivity
 - writer

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,8 +23,8 @@ importers:
         specifier: ^9.39.4
         version: 9.39.4
       '@intentsolutions/audit-harness':
-        specifier: ^1.1.5
-        version: 1.1.5
+        specifier: ^1.3.1
+        version: 1.3.1
       '@intentsolutions/core':
         specifier: 0.9.0
         version: 0.9.0
@@ -1780,8 +1780,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@intentsolutions/audit-harness@1.1.5':
-    resolution: {integrity: sha512-VbE4gPR/wtp2czWT0/Wjo5ZEtX3SRxeWMBS5nx1LhgyxdrKdZdo+deP5/km3Cl5PMyf4XbwXtVt7pDjXi0w1mQ==}
+  '@intentsolutions/audit-harness@1.3.1':
+    resolution: {integrity: sha512-GcgotqECIiIdfQLGhqJ8VxLG7UCtJdrRXTMia0VefL/njRxS02cTFXxeqde/Qb5sn5LcCAPmJcSazIPA6a2YhA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -6780,7 +6780,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.1
 
-  '@intentsolutions/audit-harness@1.1.5': {}
+  '@intentsolutions/audit-harness@1.3.1': {}
 
   '@intentsolutions/core@0.9.0':
     dependencies:

--- a/skills/.curated/builder/SKILL.md
+++ b/skills/.curated/builder/SKILL.md
@@ -9,8 +9,7 @@ version: 1.8.0
 author: Ahmed Khaled Mohamed <ahmd.khaled.a.mohamed@gmail.com>
 license: MIT
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(npm:*), Bash(node:*)
-argument-hint:
-- what to build
+argument-hint: "what to build"
 tags:
 - productivity
 - dashboard

--- a/skills/.curated/competitor-analyst/SKILL.md
+++ b/skills/.curated/competitor-analyst/SKILL.md
@@ -9,8 +9,7 @@ version: 1.8.0
 author: Ahmed Khaled Mohamed <ahmd.khaled.a.mohamed@gmail.com>
 license: MIT
 allowed-tools: Read, Glob, Grep
-argument-hint:
-- competitor or market
+argument-hint: "competitor or market"
 tags:
 - productivity
 - competitor-analyst

--- a/skills/.curated/data-analyst/SKILL.md
+++ b/skills/.curated/data-analyst/SKILL.md
@@ -9,8 +9,7 @@ version: 1.8.0
 author: Ahmed Khaled Mohamed <ahmd.khaled.a.mohamed@gmail.com>
 license: MIT
 allowed-tools: Read, Grep, Glob, Bash(npm:*), Bash(node:*)
-argument-hint:
-- metric or question
+argument-hint: "metric or question"
 tags:
 - productivity
 - database

--- a/skills/.curated/devil-advocate/SKILL.md
+++ b/skills/.curated/devil-advocate/SKILL.md
@@ -9,8 +9,7 @@ version: 1.8.0
 author: Ahmed Khaled Mohamed <ahmd.khaled.a.mohamed@gmail.com>
 license: MIT
 allowed-tools: Read, Glob, Grep
-argument-hint:
-- idea or proposal to challenge
+argument-hint: "idea or proposal to challenge"
 tags:
 - productivity
 - testing

--- a/skills/.curated/hypothesis-tester/SKILL.md
+++ b/skills/.curated/hypothesis-tester/SKILL.md
@@ -9,8 +9,7 @@ version: 1.8.0
 author: Ahmed Khaled Mohamed <ahmd.khaled.a.mohamed@gmail.com>
 license: MIT
 allowed-tools: Read, Glob, Grep
-argument-hint:
-- assumption or experiment
+argument-hint: "assumption or experiment"
 tags:
 - productivity
 - testing

--- a/skills/.curated/stakeholder-update/SKILL.md
+++ b/skills/.curated/stakeholder-update/SKILL.md
@@ -9,8 +9,7 @@ version: 1.8.0
 author: Ahmed Khaled Mohamed <ahmd.khaled.a.mohamed@gmail.com>
 license: MIT
 allowed-tools: Read, Glob, Grep
-argument-hint:
-- project or team
+argument-hint: "project or team"
 tags:
 - productivity
 - stakeholder-update

--- a/skills/.curated/technical-analyst/SKILL.md
+++ b/skills/.curated/technical-analyst/SKILL.md
@@ -9,10 +9,7 @@ version: 1.8.0
 author: Ahmed Khaled Mohamed <ahmd.khaled.a.mohamed@gmail.com>
 license: MIT
 allowed-tools: Read, Grep, Glob, Bash(git:*)
-argument-hint:
-- system
-- service
-- or file
+argument-hint: "system service or file"
 tags:
 - productivity
 - technical-analyst

--- a/skills/.curated/thought-partner/SKILL.md
+++ b/skills/.curated/thought-partner/SKILL.md
@@ -8,8 +8,7 @@ version: 1.8.0
 author: Ahmed Khaled Mohamed <ahmd.khaled.a.mohamed@gmail.com>
 license: MIT
 allowed-tools: Read, Glob, Grep
-argument-hint:
-- topic or question
+argument-hint: "topic or question"
 tags:
 - productivity
 - thought-partner

--- a/skills/.curated/writer/SKILL.md
+++ b/skills/.curated/writer/SKILL.md
@@ -8,8 +8,7 @@ version: 1.8.0
 author: Ahmed Khaled Mohamed <ahmd.khaled.a.mohamed@gmail.com>
 license: MIT
 allowed-tools: Read, Glob, Grep
-argument-hint:
-- document type or topic
+argument-hint: "document type or topic"
 tags:
 - productivity
 - writer


### PR DESCRIPTION
## What

Two unrelated defects, both surfaced by running our own tools on our own marketplace for the first time.

1. **`escape-scan` is fail-open in this repo** — bump `@intentsolutions/audit-harness` `1.1.5 → 1.3.1` (specifier **and** lockfile).
2. **12 skills carried a list-typed `argument-hint`; 1 skill had unparseable YAML** — fixed at the source, mirror regenerated.

`[skip auto-bump]`

## Why

### 1. The gate in our required chain catches nothing

We run `escape-scan` inside `ci-required`. On a constructed escape — `fail_under = 5` plus an
unquoted `lines: 5` Jest threshold, staged together:

```
1.1.5 (our pin):   (no output at all)
1.3.1:             [REFUSE] coverage fail_under lowered below policy floor (80) — escape attempt
                   [REFUSE] coverageThreshold in jest.config.js lowered below policy floor (80)
                   escape-scan: REFUSE=2 CHALLENGE=0 FLAG=0
                   escape-scan: pipeline halted (REFUSE)
```

**The precondition is present in this repo.** `escape-scan` reads `coverage.line:` / `coverage.branch:` /
`mutation.kill_rate:` from `tests/TESTING.md`, and ours records those as markdown **table rows**
(`| coverage.lines | 70 |`), so none of the three greps match. Under `set -euo pipefail` that made the
command substitution non-zero and `set -e` killed the script **mid-load, before a single check ran** —
exiting 1, which is the documented CHALLENGE code, so it looked like a warning rather than a total
bypass. Fixed upstream in `intent-audit-harness#137`, released as 1.3.1.

Bumped the **lockfile too**, not just the caret: `^1.1.5` already permitted 1.3.1, but the lockfile
pinned 1.1.5 — which is precisely how this stayed invisible.

### 2. Ten conform advisories

`audit-harness conform .` reported 9 × `$.argument-hint: expected type string, got list` plus one YAML
parse error.

## Decision rationale

**Fixed the sources, not the mirror or the generator.** The nine surfaced in `skills/.curated/`, but the
mirror is a *faithful copy* — the list form lives in the source skills under
`plugins/productivity/pm-ai-partner/`. Fixing the generator or hand-patching the mirror would have been
fixing the wrong layer and would regress on the next `promote-to-curated.py` run. Three further sources
carried the same defect without being mirrored, so **12 are fixed, not 9**.

**Quoted unconditionally** rather than only where required. Two cases would otherwise have been
re-broken by the fix itself:

- `technical-analyst` was a **three-item** sequence — a naive one-line regex leaves orphaned `- ` lines
  (I did exactly that on the first attempt and caught it on re-parse);
- `strategic-clarity`'s value is `phase: absorb/audit/articulate/align` — an inner `": "` that YAML
  reads as a nested mapping, i.e. the very defect in item 3.

## How it works

- 12 source `SKILL.md` files: block-sequence `argument-hint` → single quoted string, frontmatter
  otherwise byte-identical.
- `plugins/community/walkie-talkie/SKILL.md`: description single-quoted (it contained `Triggers: "…"`).
- `skills/.curated/` regenerated with `python3 freshie/scripts/promote-to-curated.py`
  (`selection: 1921 A/B plugin skills · promoted: 1921 · dropped: 0`).
- `package.json` + `pnpm-lock.yaml` → `audit-harness` 1.3.1.

## Verification

```
audit-harness conform .

  BEFORE   skillmd: 2446 PASS · 10 ADVISORY · 0 FAIL
  AFTER    skillmd: 2456 PASS ·  0 ADVISORY · 0 FAIL

  agent PASS · plugin NOT_APPLICABLE
```

- Every touched frontmatter re-parses, and every `argument-hint` is asserted to be a `str` (yaml.safe_load
  pass over all 12).
- `scripts/validate-skills-schema.py` exits **0** on all 13 touched skills, no errors.
- `escape-scan --staged` on 1.3.1 over this repo: `REFUSE=0 CHALLENGE=0 FLAG=0`.

**One advisory remains and is not fixable here:** `marketplace: no bundled conform schema for kind
'marketplace' in this harness version` — a gap in the harness, tracked platform-side.

## Risk

- **The harness bump makes `escape-scan` actually detect.** If a lane newly goes red, that lane was
  being silently un-gated before — treat it as a real finding, not a regression in the bump. The staged
  scan over this repo is currently clean.
- Skill changes are frontmatter-only; no body text, no behaviour, no tool grants touched.
- `argument-hint` moves from array to string — a **correction toward** the spec and the kernel schema,
  which type it as a string. Nothing consumes the array form.
- **Rollback:** revert the commit. The mirror regenerates from sources on the next `promote-curated`
  run, so no manual cleanup.

## Operational impact

No env vars, no migrations, no secrets, no deploy ordering. `pnpm install` will resolve
`audit-harness@1.3.1` on next install.

## Follow-up & deferred

- A `marketplace` conform schema belongs in the harness (platform-side).
- The deterministic `skill-conform.yml` gate — now that the corpus is at 0 advisories, `conform` can go
  required on its **own** branch-protection context (never folded into `ci-required`'s `needs:`, so a
  path-scoped skip cannot green the aggregate).

Beads: `bd_000-projects-1jn0.2` (epic), `bd_000-projects-1jn0.2.1`
Closes #1109
Closes #1110
Refs #1111
Refs intent-solutions-io/intent-eval-platform#17