### PR TITLE
fix(validator-schema): resync tool names to the canonical 43 and add the security lane

### DIFF
--- a/000-docs/SCHEMA_CHANGELOG.md
+++ b/000-docs/SCHEMA_CHANGELOG.md
@@ -146,6 +146,87 @@ compliance are welcome; structural changes to the IS rubric are not.
 
 ---
 
+## [3.16.0] — 2026-07-23 — Canonical tool names resynced (spec-compliance fix) + advisory security lane
+
+### The defect
+
+`VALID_TOOLS` held 13 hand-maintained names. The upstream Tools reference
+defines **43**, and states they are *"the exact strings you use in permission
+rules, subagent tool lists, and hook matchers"* — which makes that table the
+authority for what an `allowed-tools` entry may name.
+
+The old set listed `Task`, renamed to `Agent` in Claude Code **v2.1.63**, and
+omitted `Agent` itself along with 31 other real tools. So the gate emitted
+`not a built-in Claude Code tool` on the **correct** name while the **retired**
+one passed silently — steering marketplace authors toward a legacy alias.
+
+The rename predates this repo's spec-drift monitoring window entirely, which is
+why no drift check ever surfaced it.
+
+### Changed
+
+- `VALID_TOOLS` → the canonical 43, transcribed from a raw fetch of
+  `tools-reference.md`. Membership is **EXACT-MATCH**: `Task` is retired but
+  `TaskCreate`/`TaskGet`/`TaskList`/`TaskOutput`/`TaskStop`/`TaskUpdate` are all
+  canonical, so any prefix or substring rule mis-classifies in both directions.
+- `LEGACY_TOOL_ALIASES` (new) — `Task` → `Agent`, reported as a rename rather
+  than as unknown. Checked before the membership test, because a legacy name is
+  by definition absent from the canonical set and `difflib` would otherwise
+  suggest a misleading near-match (`Task` → `TaskGet`).
+- `RE_MCP_TOOL_REF` widened to the three documented MCP allow-rule forms
+  (`mcp__server`, `mcp__server__tool`, `mcp__server__glob`). The server segment
+  stays glob-free: upstream skips unanchored globs such as `mcp__*` with a
+  warning rather than auto-approving, so it must fall through to the
+  unknown-tool advisory instead of being blessed here.
+- **Security lane, advisory:** load-time shell substitution (`` !`cmd` `` and
+  ` ```! ` blocks) is now reported. It is PREPROCESSING — substituted before
+  Claude reads the body, not a tool call, not gated by `allowed-tools`, output
+  not re-scanned — so nothing in the validator saw it. Occurrences inside an
+  ORDINARY code fence are excluded (skills that document the syntax);
+  ` ```! ` is always counted. The documented kill switch,
+  `disableSkillShellExecution`, is named in the finding.
+- **Security lane, advisory:** `disallowed-tools` entries are validated like
+  `allowed-tools` entries. Previously only shape and the
+  allowed∩disallowed overlap were checked, so a misspelled or retired name in a
+  **deny** list matched nothing, silently. A deny rule that matches no tool is
+  worse than a missing one: it reads as a control while providing none.
+
+### Corpus effect (measured over all 3,176 marketplace `SKILL.md` with `allowed-tools`)
+
+| | count |
+|---|---|
+| spurious advisories cleared (12 `Agent`, 2 `Monitor`, 2 `TaskStop`) | 16 decls / 14 files |
+| silent `Task` declarations now advised as a rename | 137 |
+| regressions (known → unknown) | **0** |
+| files gaining the load-time-shell advisory | 103 (223 substitutions) |
+
+### Not architectural — NON-NEGOTIABLES unchanged
+
+Per NON-NEGOTIABLE #5 this is a spec-compliance fix, made autonomously.
+`ALWAYS_REQUIRED`, the tier model, and error-vs-warning semantics are all
+untouched: **every** tool diagnostic stays WARNING-level, and grades are
+unchanged across 37 sampled affected files (0 movements).
+
+`Task` warns rather than errors deliberately. The Agent SDK still emits `"Task"`
+in the `system:init` tools list and in `permission_denials[].tool_name`, so the
+name is not dead at runtime even though it is gone from the authoring surface —
+and warning→error would be an error-vs-warning semantics change, architectural
+per NON-NEGOTIABLE #7.
+
+### Verified
+
+17 new tests. Suite 54/54 in `tests/test_validate_skills_schema_frontmatter.py`;
+104 passed / 2 skipped across validator tests. Every lock mutation-verified:
+reverting `VALID_TOOLS` → 4 red; dropping `LEGACY_TOOL_ALIASES` → 1 red;
+reverting the MCP regex → 1 red; neutering shell detection → 1 red; dropping the
+`disallowed-tools` entry check → 2 red.
+
+Shell-finding line numbers are shifted into FILE coordinates via a
+`line_offset` (`validate_body` receives the body with frontmatter stripped) and
+checked against the file: reported L71 == `grep` L71.
+
+---
+
 ## [3.15.2] — 2026-07-12 — `disallowed-tools` cross-field enforcement made real (spec-compliance, additive; closes claude-41c2.2)
 
 **Additive spec-compliance implementation — no change to `ALWAYS_REQUIRED`, the

--- a/scripts/validate-skills-schema.py
+++ b/scripts/validate-skills-schema.py
@@ -189,8 +189,23 @@ except ImportError:
 #                       already-documented behavior (repo CLAUDE.md + 000-docs/681);
 #                       not an architectural change — ALWAYS_REQUIRED, tiers, and
 #                       error-vs-warning semantics are unchanged. Closes claude-41c2.2.
+# 3.16.0 (2026-07-23) — VALID_TOOLS resynced to the upstream Tools reference:
+#                       13 hand-maintained names → the canonical 43. The old set
+#                       listed `Task` (renamed to `Agent` in v2.1.63) and omitted
+#                       `Agent`, so the gate emitted a spurious "not a built-in
+#                       Claude Code tool" advisory on the CORRECT name while the
+#                       retired one passed silently — steering authors toward a
+#                       legacy alias. Adds LEGACY_TOOL_ALIASES so `Task` reports
+#                       as a rename rather than as unknown. Corpus effect at
+#                       marketplace tier: 12 spurious advisories cleared, 137
+#                       silent `Task` declarations now advised. Spec-compliance
+#                       fix (NON-NEGOTIABLE #5), not architectural: every tool
+#                       diagnostic stays WARNING-level, ALWAYS_REQUIRED and tier
+#                       semantics unchanged. Membership is EXACT-MATCH — `Task`
+#                       is retired but `TaskCreate`/`TaskGet`/`TaskList`/
+#                       `TaskOutput`/`TaskStop`/`TaskUpdate` are all canonical.
 # See 000-docs/SCHEMA_CHANGELOG.md.
-SCHEMA_VERSION = "3.15.2"
+SCHEMA_VERSION = "3.16.0"
 
 # Validation tiers
 TIER_STANDARD = "standard"
@@ -198,21 +213,84 @@ TIER_MARKETPLACE = "marketplace"
 # Backward-compat alias; --enterprise still resolves to TIER_MARKETPLACE
 TIER_ENTERPRISE = TIER_MARKETPLACE
 
-# Valid tools per Claude Code spec (2026)
+# Canonical built-in tool names, transcribed from the upstream Tools reference
+# (https://code.claude.com/docs/en/tools-reference.md, "Tools" table).
+#
+# Upstream states these are "the exact strings you use in permission rules,
+# subagent tool lists, and hook matchers" — so this set is the authority for
+# what an `allowed-tools` entry may name, and membership is EXACT-MATCH only.
+#
+# Exact-match matters more than it looks: `Task` is NOT a member, but
+# `TaskCreate`/`TaskGet`/`TaskList`/`TaskOutput`/`TaskStop`/`TaskUpdate` all
+# are. Any prefix/substring rule over this set would mis-classify both
+# directions. See LEGACY_TOOL_ALIASES below for the `Task` → `Agent` rename.
+#
+# Previously this set held 13 names hand-maintained since 2026; it listed
+# `Task` (renamed to `Agent` upstream) and omitted `Agent` itself along with 31
+# other real tools, so the gate emitted a spurious "not a built-in Claude Code
+# tool" advisory on the CORRECT name while the retired one passed silently.
 VALID_TOOLS = {
-    "Read",
-    "Write",
-    "Edit",
+    "Agent",
+    "Artifact",
+    "AskUserQuestion",
     "Bash",
+    "CronCreate",
+    "CronDelete",
+    "CronList",
+    "Edit",
+    "EndConversation",
+    "EnterPlanMode",
+    "EnterWorktree",
+    "ExitPlanMode",
+    "ExitWorktree",
     "Glob",
     "Grep",
+    "ListMcpResourcesTool",
+    "LSP",
+    "Monitor",
+    "NotebookEdit",
+    "PowerShell",
+    "PushNotification",
+    "Read",
+    "ReadMcpResourceTool",
+    "RemoteTrigger",
+    "ReportFindings",
+    "ScheduleWakeup",
+    "SendMessage",
+    "SendUserFile",
+    "ShareOnboardingGuide",
+    "Skill",
+    "TaskCreate",
+    "TaskGet",
+    "TaskList",
+    "TaskOutput",
+    "TaskStop",
+    "TaskUpdate",
+    "TodoWrite",
+    "ToolSearch",
+    "WaitForMcpServers",
     "WebFetch",
     "WebSearch",
-    "Task",
-    "TodoWrite",
-    "NotebookEdit",
-    "AskUserQuestion",
-    "Skill",
+    "Workflow",
+    "Write",
+}
+
+# Retired tool names that upstream renamed, mapped to their current spelling.
+#
+# `Task` → `Agent` landed in Claude Code v2.1.63. The rename predates this
+# repo's spec-drift monitoring window, which is why no drift check ever
+# surfaced it. `Task` appears ZERO times in the current Tools reference — not
+# even as a documented legacy alias.
+#
+# It is still warned rather than errored, deliberately, on two grounds:
+#   1. The Agent SDK continues to emit "Task" in the `system:init` tools list
+#      and in `permission_denials[].tool_name`, so the name is not fully dead
+#      at runtime even though it is gone from the authoring surface.
+#   2. Escalating a diagnostic from warning to error is an error-vs-warning
+#      semantics change — architectural per 000-docs/SCHEMA_CHANGELOG.md
+#      NON-NEGOTIABLE #7, requiring prior approval. Not in scope here.
+LEGACY_TOOL_ALIASES = {
+    "Task": "Agent",
 }
 
 # === Two-tier field definitions (Anthropic spec alignment, 2026-04-28) ===
@@ -2303,9 +2381,20 @@ def parse_allowed_tools(tools_value: Any) -> List[str]:
 
 # Well-formed base tool / server identifier (letters, digits, underscore, hyphen).
 RE_TOOL_BASE_IDENT = re.compile(r"^[A-Za-z][A-Za-z0-9_-]*$")
-# MCP tool reference: mcp__<server> or mcp__<server>__<tool> (Claude Code
-# permission-rule form; appears in the corpus, e.g. mcp__database-explorer__query_database).
-RE_MCP_TOOL_REF = re.compile(r"^mcp__[A-Za-z0-9_-]+(?:__[A-Za-z0-9_-]+)?$")
+# MCP tool reference, per the three forms upstream documents for allow rules
+# (https://code.claude.com/docs/en/permissions.md):
+#   mcp__puppeteer                      — any tool from the `puppeteer` server
+#   mcp__puppeteer__puppeteer_navigate  — one specific tool
+#   mcp__puppeteer__*  /  mcp__github__get_*
+#                                       — tool-name glob, allowed ONLY after a
+#                                         literal `mcp__<server>__` prefix
+#
+# The server segment stays glob-free on purpose: upstream requires an allow
+# rule to name a concrete configured server, and skips unanchored globs such
+# as `*`, `B*`, or `mcp__*` with a warning rather than auto-approving. Keeping
+# `*` out of the server character class is what makes `mcp__*` fall through to
+# the unknown-tool advisory instead of being silently blessed here.
+RE_MCP_TOOL_REF = re.compile(r"^mcp__[A-Za-z0-9_-]+(?:__[A-Za-z0-9_*-]+)?$")
 
 
 def validate_tool_permission(tool: str) -> Tuple[bool, str]:
@@ -2369,6 +2458,17 @@ def validate_tool_permission(tool: str) -> Tuple[bool, str]:
         inner = entry[entry.index("(") + 1 : -1].strip()
         if not inner:
             return False, f"Empty scope in allowed-tools entry: {tool}"
+
+    # Retired-but-recognised names are reported as a rename, not as "unknown".
+    # Checked before the VALID_TOOLS membership test because a legacy name is
+    # by definition absent from the canonical set, and difflib would otherwise
+    # offer a misleading near-match (`Task` → `TaskGet`).
+    if base_tool in LEGACY_TOOL_ALIASES:
+        current = LEGACY_TOOL_ALIASES[base_tool]
+        return True, (
+            f"Legacy tool name '{base_tool}' in entry '{tool}' — renamed to "
+            f"'{current}' upstream; update the declaration to '{current}'"
+        )
 
     if base_tool not in VALID_TOOLS:
         suggestion = difflib.get_close_matches(base_tool, sorted(VALID_TOOLS), n=1, cutoff=0.75)

--- a/scripts/validate-skills-schema.py
+++ b/scripts/validate-skills-schema.py
@@ -204,6 +204,21 @@ except ImportError:
 #                       semantics unchanged. Membership is EXACT-MATCH — `Task`
 #                       is retired but `TaskCreate`/`TaskGet`/`TaskList`/
 #                       `TaskOutput`/`TaskStop`/`TaskUpdate` are all canonical.
+# 3.16.0 (cont.) — security lane, all advisory:
+#                       (a) load-time shell substitution (!`cmd` and ```! blocks)
+#                       is now reported. It is PREPROCESSING — substituted before
+#                       Claude reads the body, not a tool call, not gated by
+#                       allowed-tools, output not re-scanned — so nothing in the
+#                       validator saw it before. 103 marketplace skills / 223
+#                       substitutions today. Occurrences inside an ORDINARY code
+#                       fence are excluded (skills documenting the syntax);
+#                       ```! is always counted. Line numbers are shifted into
+#                       FILE coordinates via a line_offset, since validate_body
+#                       receives the body with frontmatter stripped.
+#                       (b) disallowed-tools entries are validated like
+#                       allowed-tools. Previously only shape + the
+#                       allowed∩disallowed overlap were checked, so a misspelled
+#                       or retired name in a DENY list matched nothing, silently.
 # See 000-docs/SCHEMA_CHANGELOG.md.
 SCHEMA_VERSION = "3.16.0"
 
@@ -2956,7 +2971,22 @@ def validate_frontmatter(path: Path, fm: dict, tier: str = TIER_STANDARD) -> Tup
                 f"[frontmatter] 'disallowed-tools' must be a list of strings or a "
                 f"space/comma-separated string, got: {type(dt_val).__name__}"
             )
-        elif "allowed-tools" in fm:
+        else:
+            # Entry-level validation, mirroring allowed-tools (schema 3.16.0).
+            # Until now only the SHAPE and the allowed∩disallowed overlap were
+            # checked, so a misspelling or a retired name sat in disallowed-tools
+            # and denied nothing at all — silently, and in the one field whose
+            # entire purpose is to take capability away. A deny rule that matches
+            # no tool is strictly worse than a missing one: it reads as a control
+            # while providing none.
+            for tool in parse_allowed_tools(dt_val):
+                valid, msg = validate_tool_permission(tool)
+                if not valid:
+                    warnings.append(f"[frontmatter] disallowed-tools: {msg}")
+                elif msg:
+                    warnings.append(f"[frontmatter] disallowed-tools: {msg}")
+
+        if isinstance(dt_val, (list, str)) and "allowed-tools" in fm:
             allowed_set = set(parse_allowed_tools(fm.get("allowed-tools")))
             disallowed_set = set(parse_allowed_tools(dt_val))
             tool_overlap = allowed_set & disallowed_set
@@ -3078,8 +3108,53 @@ def validate_frontmatter(path: Path, fm: dict, tier: str = TIER_STANDARD) -> Tup
     return errors, warnings, infos
 
 
+# Load-time shell substitution, the two documented forms:
+#   !`command`   inline substitution
+#   ```!         a fenced block whose body is executed
+RE_INLINE_SHELL = re.compile(r"!`([^`\n]+)`")
+RE_SHELL_FENCE = re.compile(r"^\s*```!")
+RE_ANY_FENCE = re.compile(r"^\s*(```|~~~)")
+
+
+def _load_time_shell_hits(body: str, line_offset: int = 0) -> List[str]:
+    """Locations of load-time shell substitution, as 'L<line>: <snippet>'.
+
+    Occurrences inside an ORDINARY code fence are excluded. A large share of the
+    corpus hits are skills that document this very syntax — authoring guides
+    showing `` !`date` `` as an example — and reporting those as security
+    findings would bury the executable ones under noise, which is the failure
+    mode that gets a check ignored rather than acted on.
+
+    The ```!  fence is itself the executable form, so it is always counted; it
+    opens a shell block rather than an ordinary one.
+
+    `line_offset` shifts reported lines back into FILE coordinates. validate_body
+    receives the body with frontmatter already stripped, so an unshifted number
+    points a reviewer at the wrong line — the one defect that makes a security
+    finding actively worse than none, because it costs trust on first use.
+    """
+    hits: List[str] = []
+    in_fence = False
+    for i, line in enumerate(body.splitlines(), start=1 + line_offset):
+        if RE_SHELL_FENCE.match(line):
+            hits.append(f"L{i}: ```! block")
+            # A shell fence opens a block like any other; track it so the lines
+            # inside are not double-reported as inline hits.
+            in_fence = not in_fence
+            continue
+        if RE_ANY_FENCE.match(line):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        for m in RE_INLINE_SHELL.finditer(line):
+            cmd = m.group(1).strip()
+            hits.append(f"L{i}: !`{cmd[:40]}{'…' if len(cmd) > 40 else ''}`")
+    return hits
+
+
 def validate_body(
-    path: Path, body: str, tier: str = TIER_STANDARD, fm: dict = None
+    path: Path, body: str, tier: str = TIER_STANDARD, fm: dict = None, line_offset: int = 0
 ) -> Tuple[List[str], List[str], List[str]]:
     """
     Validate SKILL.md body content.
@@ -3091,6 +3166,33 @@ def validate_body(
     if fm is None:
         fm = {}
     lines = body.splitlines()
+
+    # === LOAD-TIME SHELL EXECUTION (schema 3.16.0) ===
+    #
+    # `` !`cmd` `` and ```` ```! ```` blocks are PREPROCESSING: Claude Code
+    # substitutes their output into the body before the model ever sees the
+    # skill. Upstream is explicit that this is "not something Claude executes"
+    # — substitution runs once and the output is NOT re-scanned. So this is not
+    # a tool call, it is not gated by allowed-tools, and no permission rule sees
+    # it. It runs on load.
+    #
+    # Reported, never blocked: this is existing, documented, widely-used
+    # behaviour, and turning a brand-new check into a merge-blocking error in
+    # the change that introduces it is how a gate loses trust. The point is to
+    # make an invisible surface reviewable — upstream's own guidance is "review
+    # project skills before trusting a repository, since a skill can grant
+    # itself broad tool access".
+    shell_hits = _load_time_shell_hits(body, line_offset)
+    if shell_hits:
+        where = ", ".join(shell_hits[:3]) + (f" (+{len(shell_hits) - 3} more)" if len(shell_hits) > 3 else "")
+        target = fm.get("shell")
+        target_note = f"; `shell: {target}` selects the interpreter" if target else ""
+        warnings.append(
+            f"[security] SKILL.md runs {len(shell_hits)} shell substitution(s) at LOAD time, before Claude "
+            f"reads the body: {where}. This is preprocessing — it is not a tool call, allowed-tools does not "
+            f"gate it, and the output is not re-scanned{target_note}. Review it as executable code. The "
+            f"documented kill switch is the `disableSkillShellExecution` setting."
+        )
 
     # === LENGTH CHECKS ===
 
@@ -4406,7 +4508,8 @@ def validate_skill(path: Path, tier: str = TIER_STANDARD) -> Dict[str, Any]:
     errors.extend(check_yaml_shell_substitution(fm))
 
     # Validate body
-    body_errors, body_warnings, body_infos = validate_body(path, body, tier, fm)
+    _body_offset = len(content.splitlines()) - len(body.splitlines())
+    body_errors, body_warnings, body_infos = validate_body(path, body, tier, fm, _body_offset)
     errors.extend(body_errors)
     warnings.extend(body_warnings)
     infos.extend(body_infos)

--- a/tests/test_validate_skills_schema_frontmatter.py
+++ b/tests/test_validate_skills_schema_frontmatter.py
@@ -493,3 +493,84 @@ def test_server_segment_glob_is_not_blessed():
     fm = {"name": "my-skill", "description": GOOD_DESC, "allowed-tools": "Read, mcp__*"}
     _, warnings, _ = _frontmatter(fm, validator.TIER_MARKETPLACE)
     assert any("mcp__*" in w for w in warnings), warnings
+
+
+# =========================================================================
+# schema 3.16.0 — security lane. Load-time shell substitution is preprocessing
+#   (not a tool call, not gated by allowed-tools); disallowed-tools entries
+#   were previously unvalidated, so a deny rule could match nothing silently.
+# =========================================================================
+
+SHELL_SKILL = """---
+name: my-skill
+description: Validate skill frontmatter fields against the published schema registry.
+---
+
+# Body
+
+Repo root: !`git rev-parse --show-toplevel`
+"""
+
+
+def test_load_time_shell_substitution_is_reported():
+    hits = validator._load_time_shell_hits("a\n!`git status`\nb")
+    assert len(hits) == 1, hits
+    assert "git status" in hits[0]
+
+
+def test_shell_hits_are_reported_in_file_line_numbers():
+    """A security finding pointing at the wrong line is worse than none."""
+    body = "x\n!`whoami`\n"
+    assert validator._load_time_shell_hits(body)[0].startswith("L2:")
+    # Frontmatter offset shifts it back into file coordinates.
+    assert validator._load_time_shell_hits(body, line_offset=10)[0].startswith("L12:")
+
+
+def test_shell_syntax_inside_an_ordinary_fence_is_not_a_finding():
+    """Skills that DOCUMENT the syntax must not be flagged as executing it."""
+    body = "```\n!`git status`\n```\n"
+    assert validator._load_time_shell_hits(body) == []
+
+
+def test_shell_fence_form_is_always_counted():
+    hits = validator._load_time_shell_hits("```!\necho hi\n```\n")
+    assert any("```! block" in h for h in hits), hits
+
+
+def test_body_check_surfaces_shell_execution_as_a_warning_not_an_error():
+    errors, warnings, _ = validator.validate_body(
+        SKILL_PATH, SHELL_SKILL.split("---", 2)[2], validator.TIER_MARKETPLACE, {"name": "my-skill"}
+    )
+    assert any("LOAD time" in w for w in warnings), warnings
+    assert not any("LOAD time" in e for e in errors), errors
+
+
+def test_disallowed_tools_entries_are_validated():
+    """A deny rule naming a non-existent tool denies nothing."""
+    fm = {"name": "my-skill", "description": GOOD_DESC, "disallowed-tools": "Wibble"}
+    _, warnings, _ = _frontmatter(fm, validator.TIER_MARKETPLACE)
+    assert any("disallowed-tools" in w and "Wibble" in w for w in warnings), warnings
+
+
+def test_disallowed_tools_flags_the_legacy_name():
+    fm = {"name": "my-skill", "description": GOOD_DESC, "disallowed-tools": "Task"}
+    _, warnings, _ = _frontmatter(fm, validator.TIER_MARKETPLACE)
+    assert any("disallowed-tools" in w and "Legacy tool name" in w for w in warnings), warnings
+
+
+def test_disallowed_tools_overlap_error_still_fires():
+    """Regression guard: entry validation must not displace the overlap rule."""
+    fm = {
+        "name": "my-skill",
+        "description": GOOD_DESC,
+        "allowed-tools": "Read",
+        "disallowed-tools": "Read",
+    }
+    errors, _, _ = _frontmatter(fm, validator.TIER_MARKETPLACE)
+    assert any("contradictory" in e for e in errors), errors
+
+
+def test_clean_disallowed_tools_is_quiet():
+    fm = {"name": "my-skill", "description": GOOD_DESC, "disallowed-tools": "Bash(rm:*), Agent"}
+    _, warnings, _ = _frontmatter(fm, validator.TIER_MARKETPLACE)
+    assert not any("disallowed-tools" in w for w in warnings), warnings

--- a/tests/test_validate_skills_schema_frontmatter.py
+++ b/tests/test_validate_skills_schema_frontmatter.py
@@ -415,3 +415,81 @@ def test_disallowed_tools_bad_shape_is_error():
     }
     errors, _warnings, _infos = _frontmatter(fm, validator.TIER_STANDARD)
     assert any("'disallowed-tools' must be" in e for e in errors), errors
+
+
+# =========================================================================
+# schema 3.16.0 — canonical tool names resynced to the upstream Tools
+#   reference. Pins the two defects the old 13-name set produced: `Agent`
+#   (correct) advised as unknown, `Task` (retired) passing silently.
+# =========================================================================
+
+
+def test_agent_is_a_canonical_tool_and_draws_no_diagnostic():
+    """`Agent` is the current name for the subagent-spawning tool."""
+    fm = {"name": "my-skill", "description": GOOD_DESC, "allowed-tools": "Read, Agent"}
+    errors, warnings, _ = _frontmatter(fm, validator.TIER_MARKETPLACE)
+    assert not any("Agent" in w and ("Unknown tool" in w or "Legacy" in w) for w in warnings), warnings
+    assert not any("allowed-tools" in e for e in errors), errors
+
+
+def test_task_reports_as_a_rename_not_as_unknown():
+    """`Task` was renamed to `Agent` in v2.1.63; it must not pass silently."""
+    fm = {"name": "my-skill", "description": GOOD_DESC, "allowed-tools": "Read, Task"}
+    errors, warnings, _ = _frontmatter(fm, validator.TIER_MARKETPLACE)
+    task_warns = [w for w in warnings if "Task" in w]
+    assert task_warns, f"Task drew no diagnostic at all: {warnings}"
+    assert any("Legacy tool name" in w and "Agent" in w for w in task_warns), task_warns
+    # Stays advisory — escalating is a semantics change (NON-NEGOTIABLE #7).
+    assert not any("Task" in e for e in errors), errors
+
+
+def test_task_prefixed_tools_are_canonical_not_legacy():
+    """Exact-match guard: TaskStop et al are real tools, unlike bare `Task`."""
+    for name in ("TaskCreate", "TaskGet", "TaskList", "TaskOutput", "TaskStop", "TaskUpdate"):
+        fm = {"name": "my-skill", "description": GOOD_DESC, "allowed-tools": f"Read, {name}"}
+        errors, warnings, _ = _frontmatter(fm, validator.TIER_MARKETPLACE)
+        assert not any(name in w and ("Unknown tool" in w or "Legacy" in w) for w in warnings), (name, warnings)
+        assert not any("allowed-tools" in e for e in errors), (name, errors)
+
+
+def test_previously_rejected_real_tools_now_accepted():
+    """Tools that existed upstream but were missing from the old 13-name set."""
+    for name in ("Monitor", "Workflow", "ToolSearch", "Artifact", "LSP", "PowerShell"):
+        fm = {"name": "my-skill", "description": GOOD_DESC, "allowed-tools": f"Read, {name}"}
+        _, warnings, _ = _frontmatter(fm, validator.TIER_MARKETPLACE)
+        assert not any(name in w and "Unknown tool" in w for w in warnings), (name, warnings)
+
+
+def test_genuinely_unknown_tool_still_advised():
+    """The resync must not turn the unknown-tool check into a no-op."""
+    fm = {"name": "my-skill", "description": GOOD_DESC, "allowed-tools": "Read, Wibble"}
+    _, warnings, _ = _frontmatter(fm, validator.TIER_MARKETPLACE)
+    assert any("Unknown tool" in w and "Wibble" in w for w in warnings), warnings
+
+
+def test_canonical_set_matches_upstream_count():
+    """43 names in the upstream Tools table; drift here is a resync signal."""
+    assert len(validator.VALID_TOOLS) == 43, sorted(validator.VALID_TOOLS)
+    assert "Task" not in validator.VALID_TOOLS
+    assert "Agent" in validator.VALID_TOOLS
+
+
+def test_mcp_permission_rule_forms():
+    """The three allow-rule forms upstream documents in permissions.md."""
+    for entry in (
+        "mcp__puppeteer",
+        "mcp__puppeteer__puppeteer_navigate",
+        "mcp__puppeteer__*",
+        "mcp__github__get_*",
+    ):
+        fm = {"name": "my-skill", "description": GOOD_DESC, "allowed-tools": f"Read, {entry}"}
+        errors, warnings, _ = _frontmatter(fm, validator.TIER_MARKETPLACE)
+        assert not any(entry in w for w in warnings), (entry, warnings)
+        assert not any("allowed-tools" in e for e in errors), (entry, errors)
+
+
+def test_server_segment_glob_is_not_blessed():
+    """`mcp__*` is an unanchored glob upstream skips; it must not pass clean."""
+    fm = {"name": "my-skill", "description": GOOD_DESC, "allowed-tools": "Read, mcp__*"}
+    _, warnings, _ = _frontmatter(fm, validator.TIER_MARKETPLACE)
+    assert any("mcp__*" in w for w in warnings), warnings


### PR DESCRIPTION
## What

Two changes to `scripts/validate-skills-schema.py` (schema 3.15.2 → 3.16.0).

**1. `VALID_TOOLS` resynced to the canonical 43.** The set was 13 hand-maintained names. It listed `Task` — renamed to `Agent` in Claude Code v2.1.63 — and omitted `Agent` itself along with 31 other real tools.

**2. Security lane (advisory).** Load-time shell substitution is now reported, and `disallowed-tools` entries are validated.

## Why

Upstream states the tool names are *"the exact strings you use in permission rules, subagent tool lists, and hook matchers"*, which makes that table the authority for what an `allowed-tools` entry may name. The gate was serving a **wrong answer**, not merely an incomplete one: it emitted `not a built-in Claude Code tool` on the correct name while the retired one passed silently, steering authors toward a legacy alias. The rename predates this repo's spec-drift monitoring window, which is why no drift check ever surfaced it.

Shell substitution is **preprocessing** — substituted into the body before Claude reads the skill, not a tool call, not gated by `allowed-tools`, output not re-scanned. Nothing in the validator saw it, on 103 skills running 223 substitutions.

`disallowed-tools` had shape + overlap checking but no entry validation, so a misspelled or retired name in a **deny** list matched nothing, silently. A deny rule matching no tool is worse than a missing one: it reads as a control while providing none.

## Decision rationale

- **Warn on `Task`, don't reject.** The Agent SDK still emits `"Task"` in the `system:init` tools list and `permission_denials[].tool_name`, so the name is not dead at runtime. Also, warning→error is architectural per `SCHEMA_CHANGELOG` NON-NEGOTIABLE #7.
- **Exact-match membership.** `Task` is retired but `TaskCreate`/`TaskGet`/`TaskList`/`TaskOutput`/`TaskStop`/`TaskUpdate` are all canonical — any prefix rule mis-classifies both directions.
- **MCP server segment stays glob-free.** Upstream skips unanchored globs like `mcp__*` with a warning rather than auto-approving, so it must fall through to the unknown-tool advisory.
- **Exclude shell syntax inside ordinary code fences.** A large share of the corpus documents this syntax; burying executable hits under authoring examples is how a check gets ignored. The ```` ```! ```` form is always counted.

## Verification

Canonical 43 transcribed from a **raw curl** of `tools-reference.md` (HTTP 200, 87,598 bytes) — not a summarizing fetcher, which truncates this page and fabricates continuations.

Corpus delta over all 3,176 marketplace `SKILL.md` with `allowed-tools`:

| | count |
|---|---|
| spurious advisories cleared (12 `Agent`, 2 `Monitor`, 2 `TaskStop`) | 16 decls / 14 files |
| silent `Task` declarations now advised | 137 |
| **regressions** | **0** |
| files gaining the shell advisory | 103 (223 substitutions) |

**Advisory-first confirmed:** every tool diagnostic stays WARNING-level; grades unchanged across 37 sampled affected files (0 movements); no new errors; no exit-code change.

17 new tests. Suite: 54/54 in the frontmatter file; 104 passed / 2 skipped across validator tests. Every lock mutation-verified:

| mutation | result |
|---|---|
| revert `VALID_TOOLS` | 4 red |
| drop `LEGACY_TOOL_ALIASES` | 1 red |
| revert MCP regex | 1 red |
| neuter shell detection | 1 red |
| drop `disallowed-tools` entry check | 2 red |

Shell finding line numbers verified against the file (reported L71 == `grep` L71) — `validate_body` receives the body with frontmatter stripped, so an unshifted number would point at the wrong line.

## Not changed (verified already correct)

Plugin-shipped agents already reject `hooks`, `mcpServers`, `permissionMode` via `AGENT_PLUGIN_RESTRICTED`. Confirmed against `plugins-reference.md` ("For security reasons, `hooks`, `mcpServers`, and `permissionMode` are not supported for plugin-shipped agents") and by running the validator on an offending agent. 3 corpus files declare them.

## Risk

Touches the gate for a 45k-download public marketplace. Effect is confined to advisory text — measured above. `SCHEMA_VERSION` bumped as required for observable output changes.

## Rollback

Single-file revert of `scripts/validate-skills-schema.py` plus the appended tests; no data migration, no config, no CI change.

Refs jeremylongshore/intent-eval-platform#14

- Jeremy Longshore
intentsolutions.io