### PR TITLE
fix(validator-schema): expand VALID_TOOLS to the canonical 43 and warn on Task→Agent

### DIFF
--- a/000-docs/SCHEMA_CHANGELOG.md
+++ b/000-docs/SCHEMA_CHANGELOG.md
@@ -146,6 +146,44 @@ compliance are welcome; structural changes to the IS rubric are not.
 
 ---
 
+## [3.16.0] — 2026-07-23 — Canonical 43-tool `VALID_TOOLS` + `Task`→`Agent` legacy alias (spec-compliance)
+
+**Additive spec-compliance bug fix — no change to `ALWAYS_REQUIRED`, the tier
+model, or error-vs-warning semantics.** Autonomous-OK class per NON-NEGOTIABLE
+#6 (aligns the allowlist with the published tools reference).
+
+### Changed
+
+- **`VALID_TOOLS`** expanded from **13** names to the full **43** built-ins from
+  [code.claude.com/docs/en/tools-reference](https://code.claude.com/docs/en/tools-reference)
+  (captured 2026-07-23). The previous set omitted `Agent` (and dozens of other
+  current tools) while listing the retired name `Task`.
+- **`Task`** moved to **`LEGACY_TOOL_ALIASES` → `Agent`**. Still accepted, but
+  emits a warning preferring `Agent` (rename since Claude Code v2.1.63; the
+  SDK still emits `Task` in some `system:init` tool lists).
+- Body-vs-allowlist tool-name regex updated to recognise the same set (plus the
+  legacy `Task` alias so body mentions still count as references).
+
+### Why this is not architectural
+
+Unknown-tool feedback was already **advisory** (WARNING), not a marketplace
+ERROR. Expanding the known set only removes false "unknown tool" warnings for
+correct modern names and adds an explicit legacy-alias warning for `Task`.
+`ALWAYS_REQUIRED`, tiers, and error-vs-warning semantics are untouched.
+
+### Evidence
+
+Pre-fix: declaring `Agent` in `allowed-tools` produced *Unknown tool 'Agent'*.
+Post-fix: clean. Declaring `Task` produces the legacy-alias warning instead of
+passing silently as a first-class tool.
+
+### Source
+
+IEP plan `golden-imagining-planet` Phase A; resumes Claude sessions
+`fix-spec-currency-loop` + `run-tools-current-spec`.
+
+---
+
 ## [3.15.2] — 2026-07-12 — `disallowed-tools` cross-field enforcement made real (spec-compliance, additive; closes claude-41c2.2)
 
 **Additive spec-compliance implementation — no change to `ALWAYS_REQUIRED`, the

--- a/marketplace/src/content/blog-posts/wrong-mode-green-is-not-a-gate.md
+++ b/marketplace/src/content/blog-posts/wrong-mode-green-is-not-a-gate.md
@@ -212,4 +212,3 @@ Wrong-mode green is not a gate. It is a board that learned to smile.
 - [Empty Is Not Clean](/posts/empty-is-not-clean/)
 - [When Green CI Proves Nothing](/posts/when-green-ci-proves-nothing/)
 - [Adversarial Review Before Team Rollout](/posts/adversarial-review-before-team-rollout/)
-

--- a/scripts/validate-skills-schema.py
+++ b/scripts/validate-skills-schema.py
@@ -189,8 +189,16 @@ except ImportError:
 #                       already-documented behavior (repo CLAUDE.md + 000-docs/681);
 #                       not an architectural change — ALWAYS_REQUIRED, tiers, and
 #                       error-vs-warning semantics are unchanged. Closes claude-41c2.2.
+# 3.16.0 (2026-07-23) — VALID_TOOLS expanded from 13 names to the full 43-tool
+#                       set from code.claude.com/docs/en/tools-reference. Adds
+#                       Agent (was missing — gate treated it as unknown) and
+#                       demotes Task to LEGACY_TOOL_ALIASES with a warn (renamed
+#                       to Agent in v2.1.63; SDK still emits Task in places).
+#                       Spec-compliance bug fix (NON-NEGOTIABLE #6) — advisory
+#                       severity only; ALWAYS_REQUIRED / tiers / error-vs-warning
+#                       unchanged. Source: IEP plan golden-imagining-planet Phase A.
 # See 000-docs/SCHEMA_CHANGELOG.md.
-SCHEMA_VERSION = "3.15.2"
+SCHEMA_VERSION = "3.16.0"
 
 # Validation tiers
 TIER_STANDARD = "standard"
@@ -198,21 +206,64 @@ TIER_MARKETPLACE = "marketplace"
 # Backward-compat alias; --enterprise still resolves to TIER_MARKETPLACE
 TIER_ENTERPRISE = TIER_MARKETPLACE
 
-# Valid tools per Claude Code spec (2026)
+# Canonical built-in tool names from code.claude.com/docs/en/tools-reference
+# (captured 2026-07-23). These are the exact strings used in permission rules,
+# subagent tool lists, and hook matchers. Count = 43.
+# Previously this set had 13 names and omitted `Agent` while listing the
+# retired alias `Task` — which made the marketplace gate reject correct
+# declarations and silently bless the legacy name (IEP plan golden-imagining-planet,
+# Phase A).
 VALID_TOOLS = {
-    "Read",
-    "Write",
-    "Edit",
+    "Agent",
+    "Artifact",
+    "AskUserQuestion",
     "Bash",
+    "CronCreate",
+    "CronDelete",
+    "CronList",
+    "Edit",
+    "EndConversation",
+    "EnterPlanMode",
+    "EnterWorktree",
+    "ExitPlanMode",
+    "ExitWorktree",
     "Glob",
     "Grep",
+    "ListMcpResourcesTool",
+    "LSP",
+    "Monitor",
+    "NotebookEdit",
+    "PowerShell",
+    "PushNotification",
+    "Read",
+    "ReadMcpResourceTool",
+    "RemoteTrigger",
+    "ReportFindings",
+    "ScheduleWakeup",
+    "SendMessage",
+    "SendUserFile",
+    "ShareOnboardingGuide",
+    "Skill",
+    "TaskCreate",
+    "TaskGet",
+    "TaskList",
+    "TaskOutput",
+    "TaskStop",
+    "TaskUpdate",
+    "TodoWrite",
+    "ToolSearch",
+    "WaitForMcpServers",
     "WebFetch",
     "WebSearch",
-    "Task",
-    "TodoWrite",
-    "NotebookEdit",
-    "AskUserQuestion",
-    "Skill",
+    "Workflow",
+    "Write",
+}
+
+# Retired names that still appear in the wild. Accept with a warning; prefer
+# the canonical name. SDK system:init still emits "Task" in some tool lists
+# even though tool_use events use "Agent" (v2.1.63+ rename).
+LEGACY_TOOL_ALIASES = {
+    "Task": "Agent",
 }
 
 # === Two-tier field definitions (Anthropic spec alignment, 2026-04-28) ===
@@ -2370,6 +2421,13 @@ def validate_tool_permission(tool: str) -> Tuple[bool, str]:
         if not inner:
             return False, f"Empty scope in allowed-tools entry: {tool}"
 
+    if base_tool in LEGACY_TOOL_ALIASES:
+        canonical = LEGACY_TOOL_ALIASES[base_tool]
+        return True, (
+            f"Legacy tool alias '{base_tool}' in entry '{tool}' — prefer '{canonical}' "
+            f"(Task was renamed to Agent in Claude Code v2.1.63; both still accepted)"
+        )
+
     if base_tool not in VALID_TOOLS:
         suggestion = difflib.get_close_matches(base_tool, sorted(VALID_TOOLS), n=1, cutoff=0.75)
         if suggestion:
@@ -3706,7 +3764,7 @@ TIER2_ORCHESTRATION_SMELLS = (
     "invokes other skills as primary",
 )
 TIER2_BASE_TOOL_PATTERN = re.compile(
-    r"\b(Read|Write|Edit|Bash|Glob|Grep|WebFetch|WebSearch|Task|TodoWrite|NotebookEdit|AskUserQuestion|Skill)\b"
+    r"\b(Agent|Artifact|AskUserQuestion|Bash|CronCreate|CronDelete|CronList|Edit|EndConversation|EnterPlanMode|EnterWorktree|ExitPlanMode|ExitWorktree|Glob|Grep|ListMcpResourcesTool|LSP|Monitor|NotebookEdit|PowerShell|PushNotification|Read|ReadMcpResourceTool|RemoteTrigger|ReportFindings|ScheduleWakeup|SendMessage|SendUserFile|ShareOnboardingGuide|Skill|Task|TaskCreate|TaskGet|TaskList|TaskOutput|TaskStop|TaskUpdate|TodoWrite|ToolSearch|WaitForMcpServers|WebFetch|WebSearch|Workflow|Write)\b"
 )
 TIER2_LITERAL_FALSE_PATTERN = re.compile(r"^\s*(if false|if \[ false \]|elif false)\b", re.MULTILINE)
 

--- a/tests/test_validate_skills_schema_frontmatter.py
+++ b/tests/test_validate_skills_schema_frontmatter.py
@@ -49,6 +49,30 @@ def test_known_bare_tools_are_valid_with_no_message():
         assert msg == "", (tool, msg)
 
 
+def test_valid_tools_is_the_canonical_43_from_tools_reference():
+    # code.claude.com/docs/en/tools-reference (captured 2026-07-23).
+    assert len(validator.VALID_TOOLS) == 43
+    assert "Agent" in validator.VALID_TOOLS
+    assert "Task" not in validator.VALID_TOOLS  # retired alias, see LEGACY_TOOL_ALIASES
+    assert "Workflow" in validator.VALID_TOOLS
+    assert "ExitPlanMode" in validator.VALID_TOOLS
+
+
+def test_agent_is_a_first_class_tool_not_unknown():
+    # Pre-3.16.0: Agent produced "Unknown tool 'Agent'" — the gate was wrong.
+    valid, msg = validator.validate_tool_permission("Agent")
+    assert valid is True
+    assert msg == "", msg
+
+
+def test_task_is_legacy_alias_of_agent_with_warning():
+    valid, msg = validator.validate_tool_permission("Task")
+    assert valid is True  # still accepted (SDK still emits Task in places)
+    assert "Legacy" in msg
+    assert "Agent" in msg
+    assert validator.LEGACY_TOOL_ALIASES["Task"] == "Agent"
+
+
 def test_scoped_colon_form_is_valid():
     valid, msg = validator.validate_tool_permission("Bash(git:*)")
     assert valid is True


### PR DESCRIPTION
## What

Expand `VALID_TOOLS` from **13** names to the full **43** built-ins from [code.claude.com/docs/en/tools-reference](https://code.claude.com/docs/en/tools-reference) (2026-07-23). Make `Agent` first-class; demote `Task` to a legacy alias of `Agent` with a warning. Schema **3.15.2 → 3.16.0**.

## Why + decision rationale

The marketplace gate was **actively wrong**, not merely incomplete: it treated correct `Agent` declarations as unknown and silently blessed the retired `Task` name (renamed in Claude Code v2.1.63). That steers ~3k marketplace skills toward a legacy alias.

Chose **accept-Task-with-warn** over reject-Task because the SDK still emits `Task` in `system:init` tool lists / permission denials. Advisory-only — no error-vs-warning change (SCHEMA_CHANGELOG NON-NEGOTIABLE #6 / #7).

## Layer(s)

- CCPI validator (`scripts/validate-skills-schema.py`)
- Schema changelog + unit tests
- **Does not** change `ALWAYS_REQUIRED`, tier model, or ERROR semantics

## How it works

- `VALID_TOOLS` = 43 names from the published tools reference
- `LEGACY_TOOL_ALIASES = {"Task": "Agent"}` → warning preferring Agent
- Body-vs-allowlist regex updated to match the same surface

## Verification & evidence

```text
pytest tests/test_validate_skills_schema_frontmatter.py -q
# 40 passed
```

Smoke: `Agent` clean; `Task` → legacy warning; count == 43.

## Risk assessment

- Low: unknown-tool feedback was already WARNING-level
- Corpus delta: fewer false "unknown" warnings for modern tools; `Task` decls gain an explicit legacy warning
- Land advisory first (already advisory); no corpus remediation required to merge

## Operational impact

None (no secrets, deploys, or deps).

## Follow-up

IEP plan `golden-imagining-planet` remaining phases B–F (section coverage, extraction widening, shell-exec detection, Wave 3 SoT, kernel fold). Lab PR #242 merged; #243 auto-promotion rebasing.

## Refs

- IEP plan: `~/.claude/plans/golden-imagining-planet.md` Phase A
- Claude sessions: `fix-spec-currency-loop`, `run-tools-current-spec`
- Closes nothing yet (tracking under `bd_000-projects-1jn0` / intent-eval-platform#10)