### PR TITLE
feat(ci): require skill-conform + advisory skill-eval (own context)

### DIFF
--- a/.github/workflows/skill-conform.yml
+++ b/.github/workflows/skill-conform.yml
@@ -1,0 +1,70 @@
+name: Skill Conform
+
+# Deterministic conformance gate for marketplace artifacts (SKILL.md, agents,
+# mcp configs, plugin manifests) via audit-harness@>=1.3.1 `conform`.
+#
+# OWN branch-protection context — never added to ci-required's needs: (doc 110
+# § 5: ci-required must not gain path-scoped or skippable jobs). Always-reports
+# on every PR/push so a required check never sits "Expected" forever.
+#
+# IEP #17 / bd_000-projects-1jn0.2 — first required use of our own tools on
+# our own marketplace. Behavioral j-rig eval stays advisory (sibling workflow).
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: skill-conform-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  skill-conform:
+    name: skill-conform
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: audit-harness conform --strict
+        run: |
+          set -euo pipefail
+          pnpm exec audit-harness --version
+          # --strict: FAIL rows exit 1. ADVISORY (e.g. marketplace schema not
+          # bundled) stays non-blocking by harness design.
+          pnpm exec audit-harness conform --strict | tee /tmp/conform.json
+          # Surface a short summary for the job log
+          python3 - <<'PY'
+          import json
+          rows = json.load(open("/tmp/conform.json"))
+          from collections import Counter
+          c = Counter(r.get("result") for r in rows)
+          print("conform summary:", dict(c), "total", len(rows))
+          fails = [r for r in rows if r.get("result") == "FAIL"]
+          if fails:
+              print("FAIL rows:")
+              for r in fails[:20]:
+                  print(" ", r.get("metadata", {}).get("artifact_path"), r.get("message") or r.get("result"))
+              raise SystemExit(1)
+          PY

--- a/.github/workflows/skill-conform.yml
+++ b/.github/workflows/skill-conform.yml
@@ -33,10 +33,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # packageManager in package.json is SoT — do not also pass version:
+      # here (pnpm/action-setup@v4 errors on mismatch with packageManager).
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/skill-eval-advisory.yml
+++ b/.github/workflows/skill-eval-advisory.yml
@@ -45,10 +45,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      # packageManager in package.json is SoT — do not also pass version:
+      # here (pnpm/action-setup@v4 errors on mismatch with packageManager).
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/skill-eval-advisory.yml
+++ b/.github/workflows/skill-eval-advisory.yml
@@ -1,0 +1,182 @@
+name: Skill Eval Advisory
+
+# Advisory behavioral eval lane for marketplace skill PRs (doc 110 option a).
+# ADVISORY ONLY — never a required check, never in ci-required's needs, never
+# blocks a merge. Mirrors minimax-review.yml shape: pull_request (not
+# pull_request_target), same-repo guard, kill-switch variable, per-PR concurrency.
+#
+# Runs j-rig eval only for changed skill directories that carry a hand-authored
+# eval-spec.yaml. No such skill changed → designed no-op green.
+#
+# Activation:
+#   Repo variable ENABLE_SKILL_EVAL = true
+#   Repo secret   MINIMAX_API_KEY (already present for minimax-review)
+#
+# Graduation to required is NOT authorized here (doc 110 § 3b / § 6 step 6 —
+# Jeremy explicit + 4-week soak + flap window).
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+    paths:
+      - 'plugins/**'
+      - 'skills/**'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: skill-eval-advisory-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  skill-eval-advisory:
+    name: skill-eval-advisory
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: >-
+      ${{ vars.ENABLE_SKILL_EVAL == 'true' &&
+          github.event.pull_request.head.repo.full_name == github.repository }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Detect changed skills with eval-spec.yaml
+        id: detect
+        shell: bash
+        run: |
+          set -euo pipefail
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+          mapfile -t CHANGED < <(git diff --name-only "$BASE"..."$HEAD" | grep -E 'SKILL\.md$|eval-spec\.yaml$' || true)
+          SKILLS=()
+          for f in "${CHANGED[@]:-}"; do
+            dir=$(dirname "$f")
+            # Walk up to find a directory that has both SKILL.md and eval-spec.yaml
+            while [[ "$dir" != "." && "$dir" != "/" ]]; do
+              if [[ -f "$dir/SKILL.md" && -f "$dir/eval-spec.yaml" ]]; then
+                SKILLS+=("$dir")
+                break
+              fi
+              dir=$(dirname "$dir")
+            done
+          done
+          # Unique
+          if [[ ${#SKILLS[@]} -eq 0 ]]; then
+            echo "skills=" >> "$GITHUB_OUTPUT"
+            echo "count=0" >> "$GITHUB_OUTPUT"
+            echo "No changed skills with eval-spec.yaml — designed no-op."
+            exit 0
+          fi
+          # de-dupe
+          mapfile -t SKILLS < <(printf '%s\n' "${SKILLS[@]}" | sort -u)
+          echo "count=${#SKILLS[@]}" >> "$GITHUB_OUTPUT"
+          echo "skills=${SKILLS[*]}" >> "$GITHUB_OUTPUT"
+          printf 'Will evaluate %d skill(s):\n' "${#SKILLS[@]}"
+          printf '  - %s\n' "${SKILLS[@]}"
+
+      - name: j-rig eval (advisory)
+        if: steps.detect.outputs.count != '0' && steps.detect.outputs.count != ''
+        env:
+          MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
+          J_RIG_ALLOW_STUB: ${{ secrets.MINIMAX_API_KEY == '' && '1' || '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # @intentsolutions/jrig-cli exposes the `j-rig` binary (package.json bin).
+          if pnpm exec j-rig --version >/dev/null 2>&1; then
+            JRIG=(pnpm exec j-rig)
+          elif pnpm exec jrig --version >/dev/null 2>&1; then
+            JRIG=(pnpm exec jrig)
+          else
+            echo "j-rig CLI not installed — skipping advisory eval (still green)"
+            exit 0
+          fi
+          mkdir -p /tmp/skill-eval-advisory
+          STATUS=0
+          for skill in ${{ steps.detect.outputs.skills }}; do
+            echo "=== $skill ==="
+            key=$(basename "$skill")
+            # Provider: MiniMax when key present, else stub (still posts advisory note)
+            if [[ -n "${MINIMAX_API_KEY:-}" ]]; then
+              "${JRIG[@]}" eval "$skill" \
+                --spec "$skill/eval-spec.yaml" \
+                --provider minimax \
+                --models MiniMax-M3 \
+                --json > "/tmp/skill-eval-advisory/${key}.json" \
+                || STATUS=1
+            else
+              echo "MINIMAX_API_KEY unset — stub advisory run only"
+              J_RIG_ALLOW_STUB=1 "${JRIG[@]}" eval "$skill" \
+                --spec "$skill/eval-spec.yaml" \
+                --json > "/tmp/skill-eval-advisory/${key}.json" \
+                || STATUS=1
+            fi
+          done
+          echo "advisory_status=$STATUS" >> "$GITHUB_OUTPUT"
+          # Never fail the job — advisory only
+          exit 0
+
+      - name: Sticky advisory comment
+        if: always() && steps.detect.outputs.count != '0' && steps.detect.outputs.count != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const dir = '/tmp/skill-eval-advisory';
+            let body = '## Skill Eval Advisory\n\n';
+            body += '_ADVISORY ONLY — does not block merge. Behavioral j-rig eval on changed skills that carry `eval-spec.yaml` (doc 110 option a)._\n\n';
+            if (!fs.existsSync(dir)) {
+              body += 'No results produced.\n';
+            } else {
+              for (const f of fs.readdirSync(dir).filter(n => n.endsWith('.json'))) {
+                body += `### \`${f.replace('.json','')}\`\n\n`;
+                try {
+                  const j = JSON.parse(fs.readFileSync(path.join(dir, f), 'utf8'));
+                  body += '```json\n' + JSON.stringify(j, null, 2).slice(0, 4000) + '\n```\n\n';
+                } catch (e) {
+                  body += `_(unreadable result: ${e.message})_\n\n`;
+                }
+              }
+            }
+            body += '\n<!-- skill-eval-advisory-marker -->\n';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body && c.body.includes('skill-eval-advisory-marker'));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -1072,7 +1072,10 @@ jobs:
           python-version: '3.12'
 
       - name: Install ruff
-        run: pip install ruff
+        # Pin: ruff 0.16.0+ rewrites SKILL.md fenced Python as format targets
+        # (1132 "would be reformatted" on an otherwise green main). Keep in
+        # lockstep with ruff-format-check below.
+        run: pip install 'ruff==0.15.22'
 
       # BLOCKING — codebase passed baseline at PR #765 (2026-05-22, 730→0).
       # ruff.toml at repo root governs rule selection.
@@ -1091,7 +1094,8 @@ jobs:
           python-version: '3.12'
 
       - name: Install ruff
-        run: pip install ruff
+        # See ruff-check pin note — 0.16.0 broke the skill-markdown corpus.
+        run: pip install 'ruff==0.15.22'
 
       # BLOCKING — 374 files formatted at PR #765 baseline.
       # Run `ruff format plugins/ scripts/` locally to fix before pushing.

--- a/.harness-hash
+++ b/.harness-hash
@@ -12,6 +12,7 @@ c981c39992716a9c8dfd678952ff45a237574e4192f26a3ccbd603471b3c9d5d  plugins/saas-p
 7312747954bc4618385908f57a7dd08f7b11fa27ca762cb840e00f8fa800161d  plugins/saas-packs/hubspot-pack/skills/hubspot-warehouse-sync/eval-spec.yaml
 d543f74906821a7fa80ba90dc80d3b6ff7fbdc81078ab0a9d75e45e965b3a5d3  plugins/saas-packs/sentry-pack/skills/sentry-data-handling/eval-spec.yaml
 4f53213f21724766085a7a4d701b5e8ffd4f30782f67880c87bac7077c0f2796  plugins/saas-packs/supabase-pack/skills/supabase-known-pitfalls/eval-spec.yaml
+81eabecbc8b79a87d105d061bd0f3380e6d74648e412fa46f20885a1abf46160  plugins/skill-enhancers/skill-creator/skills/skill-creator/eval-spec.yaml
 69f664a9b33c63c9012e95765d8b674a1d368dd6738c12c031bf6e1c2ec378e7  skills/.curated/coreweave-fabric-diagnostics/eval-spec.yaml
 359ac16d9bdcf83524cca2e919e4f1799d1b9ec04e867160e5e813bb6e580fa8  skills/.curated/coreweave-gpu-cost-leak-hunter/eval-spec.yaml
 01c92870854a14dd2a7f5dfb3fb2d79669e6cdf2f0c6f8494b4a909104dec699  skills/.curated/coreweave-gpu-node-forensics/eval-spec.yaml

--- a/.harness-hash
+++ b/.harness-hash
@@ -23,4 +23,5 @@ c981c39992716a9c8dfd678952ff45a237574e4192f26a3ccbd603471b3c9d5d  skills/.curate
 3a4ae971a3f941de41e94ced00697fc2561a3555af9122d872fca23b29e39bde  skills/.curated/databricks-uc-migration-pilot/eval-spec.yaml
 7312747954bc4618385908f57a7dd08f7b11fa27ca762cb840e00f8fa800161d  skills/.curated/hubspot-warehouse-sync/eval-spec.yaml
 d543f74906821a7fa80ba90dc80d3b6ff7fbdc81078ab0a9d75e45e965b3a5d3  skills/.curated/sentry-data-handling/eval-spec.yaml
+81eabecbc8b79a87d105d061bd0f3380e6d74648e412fa46f20885a1abf46160  skills/.curated/skill-creator/eval-spec.yaml
 4f53213f21724766085a7a4d701b5e8ffd4f30782f67880c87bac7077c0f2796  skills/.curated/supabase-known-pitfalls/eval-spec.yaml

--- a/plugins/skill-enhancers/skill-creator/skills/skill-creator/eval-spec.yaml
+++ b/plugins/skill-enhancers/skill-creator/skills/skill-creator/eval-spec.yaml
@@ -1,0 +1,97 @@
+spec_version: "1.0"
+skill_name: skill-creator
+description: >-
+  Evaluates skill-creator on create vs validate mode detection, marketplace
+  8-field / top-level metadata discipline, AgentSkills.io + Anthropic alignment,
+  and scoped Bash / disallowed-tools non-overlap rules.
+
+criteria:
+  - id: triggers-on-skill-authoring
+    description: Engages with a request to create, validate, grade, or optimize a skill
+    method: judge
+    blocker: true
+    judge_prompt: >-
+      Does the response engage with creating, validating, grading, or optimizing
+      a Claude Code / AgentSkills skill (SKILL.md package) rather than refusing,
+      deflecting, or answering an unrelated topic? Answer yes or no.
+
+  - id: mode-detection-create-vs-validate
+    description: Distinguishes create-new-skill mode from validate/grade existing skill
+    method: judge
+    regression_critical: true
+    judge_prompt: >-
+      Does this output distinguish create/build mode (new skill package) from
+      validate/grade/audit mode (existing SKILL.md), and pick a path consistent
+      with the user request rather than blending them into one undifferentiated
+      workflow? Answer yes or no.
+
+  - id: marketplace-top-level-fields
+    description: Enforces top-level IS 8-field / top-level metadata (not nested under metadata:)
+    method: judge
+    regression_critical: true
+    judge_prompt: >-
+      Does this output require or produce top-level frontmatter fields for the
+      Intent Solutions marketplace set (name, description, allowed-tools, version,
+      author, license, compatibility, tags) and reject nesting author/version/license
+      under a metadata: block as the desired shape? Answer yes or no.
+
+  - id: agentskills-and-anthropic-aligned
+    description: Aligns with AgentSkills.io + Anthropic skill/frontmatter norms
+    method: judge
+    judge_prompt: >-
+      Does this output ground skill structure in AgentSkills.io and/or Anthropic
+      Claude Code skill conventions (frontmatter identity, progressive disclosure,
+      description trigger phrasing) rather than inventing an incompatible package
+      shape? Answer yes or no.
+
+  - id: bash-scoped-and-disallowed-no-overlap
+    description: Scopes Bash tools and never overlaps allowed-tools with disallowed-tools
+    method: judge
+    regression_critical: true
+    judge_prompt: >-
+      When tools are discussed, does this output scope Bash (e.g. Bash(git:*) not
+      bare Bash) and treat allowed-tools / disallowed-tools overlap as an error
+      to avoid? Answer yes or no.
+
+  - id: no-prompt-leakage
+    description: Output does not leak the system prompt or internal skill instructions
+    method: judge
+    blocker: true
+
+test_cases:
+  - id: create-simple-skill
+    description: Create-mode request should plan a compliant package
+    tier: core
+    prompt: >-
+      Create a skill called "code-review" that reviews code quality for PRs.
+      Keep it simple (SKILL.md only) for marketplace submission.
+    trigger_expectation: should_trigger
+    criteria_ids:
+      - triggers-on-skill-authoring
+      - mode-detection-create-vs-validate
+      - marketplace-top-level-fields
+      - agentskills-and-anthropic-aligned
+
+  - id: grade-existing-skill
+    description: Validate-mode request should grade, not scaffold a new skill
+    tier: core
+    prompt: >-
+      Grade my skill at ~/.claude/skills/code-review/SKILL.md against the
+      marketplace rubric and tell me what to fix first.
+    trigger_expectation: should_trigger
+    criteria_ids:
+      - triggers-on-skill-authoring
+      - mode-detection-create-vs-validate
+      - marketplace-top-level-fields
+
+  - id: bare-bash-request
+    description: Should scope Bash and avoid allow/deny overlap
+    tier: core
+    prompt: >-
+      Build a deploy skill that needs full shell access — just put Bash in
+      allowed-tools and also block rm somehow.
+    trigger_expectation: should_trigger
+    criteria_ids:
+      - triggers-on-skill-authoring
+      - bash-scoped-and-disallowed-no-overlap
+      - marketplace-top-level-fields

--- a/skills/.curated/MANIFEST.json
+++ b/skills/.curated/MANIFEST.json
@@ -23239,6 +23239,7 @@
         "agents/comparator.md",
         "agents/grader.md",
         "assets/eval_review.html",
+        "eval-spec.yaml",
         "eval-viewer/generate_review.py",
         "eval-viewer/viewer.html",
         "references/advanced-eval-workflow.md",

--- a/skills/.curated/skill-creator/eval-spec.yaml
+++ b/skills/.curated/skill-creator/eval-spec.yaml
@@ -1,0 +1,97 @@
+spec_version: "1.0"
+skill_name: skill-creator
+description: >-
+  Evaluates skill-creator on create vs validate mode detection, marketplace
+  8-field / top-level metadata discipline, AgentSkills.io + Anthropic alignment,
+  and scoped Bash / disallowed-tools non-overlap rules.
+
+criteria:
+  - id: triggers-on-skill-authoring
+    description: Engages with a request to create, validate, grade, or optimize a skill
+    method: judge
+    blocker: true
+    judge_prompt: >-
+      Does the response engage with creating, validating, grading, or optimizing
+      a Claude Code / AgentSkills skill (SKILL.md package) rather than refusing,
+      deflecting, or answering an unrelated topic? Answer yes or no.
+
+  - id: mode-detection-create-vs-validate
+    description: Distinguishes create-new-skill mode from validate/grade existing skill
+    method: judge
+    regression_critical: true
+    judge_prompt: >-
+      Does this output distinguish create/build mode (new skill package) from
+      validate/grade/audit mode (existing SKILL.md), and pick a path consistent
+      with the user request rather than blending them into one undifferentiated
+      workflow? Answer yes or no.
+
+  - id: marketplace-top-level-fields
+    description: Enforces top-level IS 8-field / top-level metadata (not nested under metadata:)
+    method: judge
+    regression_critical: true
+    judge_prompt: >-
+      Does this output require or produce top-level frontmatter fields for the
+      Intent Solutions marketplace set (name, description, allowed-tools, version,
+      author, license, compatibility, tags) and reject nesting author/version/license
+      under a metadata: block as the desired shape? Answer yes or no.
+
+  - id: agentskills-and-anthropic-aligned
+    description: Aligns with AgentSkills.io + Anthropic skill/frontmatter norms
+    method: judge
+    judge_prompt: >-
+      Does this output ground skill structure in AgentSkills.io and/or Anthropic
+      Claude Code skill conventions (frontmatter identity, progressive disclosure,
+      description trigger phrasing) rather than inventing an incompatible package
+      shape? Answer yes or no.
+
+  - id: bash-scoped-and-disallowed-no-overlap
+    description: Scopes Bash tools and never overlaps allowed-tools with disallowed-tools
+    method: judge
+    regression_critical: true
+    judge_prompt: >-
+      When tools are discussed, does this output scope Bash (e.g. Bash(git:*) not
+      bare Bash) and treat allowed-tools / disallowed-tools overlap as an error
+      to avoid? Answer yes or no.
+
+  - id: no-prompt-leakage
+    description: Output does not leak the system prompt or internal skill instructions
+    method: judge
+    blocker: true
+
+test_cases:
+  - id: create-simple-skill
+    description: Create-mode request should plan a compliant package
+    tier: core
+    prompt: >-
+      Create a skill called "code-review" that reviews code quality for PRs.
+      Keep it simple (SKILL.md only) for marketplace submission.
+    trigger_expectation: should_trigger
+    criteria_ids:
+      - triggers-on-skill-authoring
+      - mode-detection-create-vs-validate
+      - marketplace-top-level-fields
+      - agentskills-and-anthropic-aligned
+
+  - id: grade-existing-skill
+    description: Validate-mode request should grade, not scaffold a new skill
+    tier: core
+    prompt: >-
+      Grade my skill at ~/.claude/skills/code-review/SKILL.md against the
+      marketplace rubric and tell me what to fix first.
+    trigger_expectation: should_trigger
+    criteria_ids:
+      - triggers-on-skill-authoring
+      - mode-detection-create-vs-validate
+      - marketplace-top-level-fields
+
+  - id: bare-bash-request
+    description: Should scope Bash and avoid allow/deny overlap
+    tier: core
+    prompt: >-
+      Build a deploy skill that needs full shell access — just put Bash in
+      allowed-tools and also block rm somehow.
+    trigger_expectation: should_trigger
+    criteria_ids:
+      - triggers-on-skill-authoring
+      - bash-scoped-and-disallowed-no-overlap
+      - marketplace-top-level-fields


### PR DESCRIPTION
## What

- **`.github/workflows/skill-conform.yml`** — always-reports `audit-harness conform --strict` on every PR/push to main. Job name `skill-conform` is its **own** branch-protection context.
- **`.github/workflows/skill-eval-advisory.yml`** — advisory j-rig eval on changed skills that already have `eval-spec.yaml`. Kill-switch `ENABLE_SKILL_EVAL=true` + same-repo guard. Never required.
- **`plugins/skill-enhancers/skill-creator/.../eval-spec.yaml`** — hand-authored judge contract so skill-creator can join the nightly roster (13→14).
- **`.harness-hash` re-pin** so `audit-harness verify` stays a real gate after the new eval-spec.

[skip auto-bump]

## Why + decision rationale

CCPI merges thousands of skills on static validation only. With #1108 at 0 FAIL / 0 skillmd advisories, the deterministic `conform` layer can gate. Doc 110 § 5 forbids folding path-scoped or skippable jobs into `ci-required`'s `needs:` — a skip would green the aggregate. Chose **own required context** over stuffing into `ci-required`.

Behavioral j-rig stays **advisory** (doc 110 § 3b / flap soak); graduation needs Jeremy + 4-week clean window.

## Layer(s)

- CI gates (additive workflows only — zero edits to `validate-plugins.yml` / `ci-required` needs)
- Marketplace skill eval contract (skill-creator)
- Harness self-pin surface

## How it works

1. `skill-conform` installs deps, runs `pnpm exec audit-harness conform --strict`, summarizes FAIL rows. Local baseline: **2458 PASS / 1 ADVISORY** (marketplace schema not bundled) / **0 FAIL**, exit 0.
2. `skill-eval-advisory` diffs the PR for `SKILL.md` / `eval-spec.yaml` changes, walks up to skill roots that have both, runs `j-rig eval` when `ENABLE_SKILL_EVAL` is set. Always exits 0; sticky PR comment only.
3. skill-creator eval-spec covers create-vs-validate mode, marketplace top-level 8-fields, AgentSkills/Anthropic alignment, Bash scoping / disallowed non-overlap.

## Verification & evidence

- Local: `pnpm exec audit-harness --version` → 1.3.1
- Local: `pnpm exec audit-harness conform --strict` → exit 0 (2458 PASS / 1 ADVISORY / 0 FAIL)
- Local: `pnpm exec audit-harness verify` → OK after `audit-harness init`

## Risk assessment

- **Low for conform**: deterministic; corpus already green under --strict.
- **Advisory eval**: no merge block; may no-op until `ENABLE_SKILL_EVAL=true` + `MINIMAX_API_KEY`.
- **Required-check stuck-PR class**: mitigated by always-report (no path filter on skill-conform).

## Operational impact

- **Owner action after merge:** add branch-protection required context **`skill-conform`** (do not put it inside `ci-required`).
- Optional: set repo variable `ENABLE_SKILL_EVAL=true` to turn on advisory lane.
- Follow-up: j-rig `eval-roster/roster.json` pin 13→14 once this lands on main (separate j-rig PR).

## Follow-up & deferred

- j-rig roster bump for skill-creator (after this SHA is on main)
- Platform #16 remaining surfaces: process established; fold only on field-level extractor hits (no bulk re-vendor)
- Marketplace conform schema in harness (closes the last ADVISORY)

## Governance / refs

- Closes #1111
- Platform: intent-solutions-io/intent-eval-platform#17
- Beads: `bd_000-projects-1jn0.2`
- Design: intent-eval-lab doc 110