### PR TITLE
feat: security lane 3.16.1 and walkie-talkie B-grade

### DIFF
--- a/000-docs/SCHEMA_CHANGELOG.md
+++ b/000-docs/SCHEMA_CHANGELOG.md
@@ -146,6 +146,30 @@ compliance are welcome; structural changes to the IS rubric are not.
 
 ---
 
+## [3.16.1] — 2026-07-23 — Security lane: load-time shell + disallowed-tools entry validation (advisory)
+
+**Additive advisory-only surface — no change to `ALWAYS_REQUIRED`, tiers, or
+error-vs-warning semantics for required fields.** Residual of closed PR #1113
+(VALID_TOOLS portion already shipped as 3.16.0 via #1115).
+
+### Added
+
+- **Load-time shell substitution findings** on SKILL.md bodies: `` !`cmd` `` and
+  ` ```! ` blocks reported as `[security]` warnings (not errors). Ordinary
+  fenced documentation of the syntax is excluded. Kill switch named:
+  `disableSkillShellExecution`.
+- **`disallowed-tools` entry validation** mirroring `allowed-tools` — misspelled
+  or legacy names in a deny list no longer pass silently (a deny that matches
+  nothing is worse than a missing deny).
+
+### Why advisory
+
+This is widely used, documented Claude Code preprocessing. Making the first
+detection of it a merge-blocking error would burn trust. The goal is reviewable
+surface, not a sudden corpus red wall.
+
+---
+
 ## [3.16.0] — 2026-07-23 — Canonical 43-tool `VALID_TOOLS` + `Task`→`Agent` legacy alias (spec-compliance)
 
 **Additive spec-compliance bug fix — no change to `ALWAYS_REQUIRED`, the tier

--- a/plugins/community/walkie-talkie/SKILL.md
+++ b/plugins/community/walkie-talkie/SKILL.md
@@ -1,8 +1,23 @@
 ---
 name: walkie-talkie
-description: 'Use when two or more agent sessions — same or different platforms (Claude Code, Codex, Gemini CLI, Copilot, Cursor) — work the same repo concurrently, hand off in-flight work, or need to interrogate each other about a handoff. Triggers: "set up comms with the other session", "hand this off to Codex/Gemini", "grill the handoff", "check the mailbox", parallel sessions clobbering shared files, resuming work another agent left half-done.'
+description: >-
+  Use when two or more agent sessions — same or different platforms (Claude Code,
+  Codex, Gemini CLI, Copilot, Cursor) — work the same repo concurrently, hand off
+  in-flight work, or need to interrogate each other about a handoff. Triggers:
+  "set up comms with the other session", "hand this off to Codex/Gemini", "grill
+  the handoff", "check the mailbox", parallel sessions clobbering shared files,
+  resuming work another agent left half-done. Trigger with "/walkie-talkie".
+allowed-tools: Read,Write,Edit,Glob,Grep,Bash(git:*)
+version: 1.0.0
+author: Jeremy Longshore <jeremy@intentsolutions.io>
+license: MIT
+compatibility: Designed for Claude Code; also usable from Codex/Gemini/Copilot/Cursor sessions that can read and write files
+tags:
+  - multi-agent
+  - coordination
+  - handoff
+  - mailbox
 ---
-
 # Walkie-Talkie
 
 ## Overview
@@ -89,3 +104,54 @@ Any grill question that cannot be answered with evidence is recorded as a **RISK
 | Mailbox only written at session end | Checkpoint cadence: start, before each slice, after each slice |
 | Protocol described only in chat | README.md in the comms dir + shims in CLAUDE.md/AGENTS.md/GEMINI.md |
 | Committing code without its mailbox entry | Commit them together — a pull must never show unexplained code |
+
+## Prerequisites
+
+- A shared git repo both sessions can pull/push
+- Write access to create `comms/` (or an agreed path) and one outbox file per agent handle
+- Participating platforms that auto-read at least one bootstrap file (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, …)
+
+## Instructions
+
+Follow the Setup / Message Format / Grill sections above. Non-negotiables:
+
+1. One writer per outbox file; append-only.
+2. Never edit another agent's outbox.
+3. Commit mailbox updates with the code they describe.
+4. On handoff receipt, run the Grill before trusting claims.
+
+## Output
+
+- A `comms/` (or agreed) mailbox directory with `README.md` (protocol) and `<HANDLE>.md` outboxes
+- Appended status / handoff / ACTION-REQUESTED entries with timestamps
+- Optional Grill notes on the receiving agent's outbox after interrogation
+
+## Examples
+
+### Two Claude sessions hand off mid-feature
+
+```
+Session A: /walkie-talkie set up comms at .agents/comms/
+Session A: writes STATUS + handoff with file:line load-bearing state
+Session B: reads mailbox, grills ambiguous claims, continues work
+```
+
+### Claude → Codex handoff
+
+```
+Session A (Claude): creates comms/, appends handoff entry
+Human: git push; opens Codex on same branch
+Session B (Codex): reads AGENTS.md → mailbox path → grills → continues
+```
+
+## Edge Cases
+
+- **Same-harness Claude-only teams:** prefer Agent Teams / SendMessage; this skill is for heterogeneous or cross-machine sessions.
+- **Empty peer outbox:** initialize with a one-line pointer to README so first read routes correctly.
+- **Merge conflicts on outboxes:** design forbids multi-writer files; if it happens, treat as process break and re-split by handle.
+- **Stale handoff:** Grill for freshness (commit SHA, branch tip, uncommitted work) before applying.
+
+## Resources
+
+- Protocol template: [PROTOCOL_TEMPLATE.md](PROTOCOL_TEMPLATE.md)
+- Package metadata: [package.json](package.json)

--- a/scripts/validate-skills-schema.py
+++ b/scripts/validate-skills-schema.py
@@ -3101,9 +3101,7 @@ def validate_body(
     # Preprocessing, not a tool call; allowed-tools does not gate it.
     shell_hits = _load_time_shell_hits(body, line_offset)
     if shell_hits:
-        where = ", ".join(shell_hits[:3]) + (
-            f" (+{len(shell_hits) - 3} more)" if len(shell_hits) > 3 else ""
-        )
+        where = ", ".join(shell_hits[:3]) + (f" (+{len(shell_hits) - 3} more)" if len(shell_hits) > 3 else "")
         target = fm.get("shell")
         target_note = f"; `shell: {target}` selects the interpreter" if target else ""
         warnings.append(

--- a/scripts/validate-skills-schema.py
+++ b/scripts/validate-skills-schema.py
@@ -197,8 +197,11 @@ except ImportError:
 #                       Spec-compliance bug fix (NON-NEGOTIABLE #6) — advisory
 #                       severity only; ALWAYS_REQUIRED / tiers / error-vs-warning
 #                       unchanged. Source: IEP plan golden-imagining-planet Phase A.
+# 3.16.1 (2026-07-23) — security lane (advisory only): load-time shell
+#                       substitution (!`cmd` / ```!) + disallowed-tools entry
+#                       validation (mirrors allowed-tools). Residual of closed #1113.
 # See 000-docs/SCHEMA_CHANGELOG.md.
-SCHEMA_VERSION = "3.16.0"
+SCHEMA_VERSION = "3.16.1"
 
 # Validation tiers
 TIER_STANDARD = "standard"
@@ -2914,7 +2917,17 @@ def validate_frontmatter(path: Path, fm: dict, tier: str = TIER_STANDARD) -> Tup
                 f"[frontmatter] 'disallowed-tools' must be a list of strings or a "
                 f"space/comma-separated string, got: {type(dt_val).__name__}"
             )
-        elif "allowed-tools" in fm:
+        else:
+            # Entry-level validation, mirroring allowed-tools (schema 3.16.1).
+            # A misspelling or retired name in a deny list matched nothing silently.
+            for tool in parse_allowed_tools(dt_val):
+                valid, msg = validate_tool_permission(tool)
+                if not valid:
+                    warnings.append(f"[frontmatter] disallowed-tools: {msg}")
+                elif msg:
+                    warnings.append(f"[frontmatter] disallowed-tools: {msg}")
+
+        if isinstance(dt_val, (list, str)) and "allowed-tools" in fm:
             allowed_set = set(parse_allowed_tools(fm.get("allowed-tools")))
             disallowed_set = set(parse_allowed_tools(dt_val))
             tool_overlap = allowed_set & disallowed_set
@@ -3036,8 +3049,42 @@ def validate_frontmatter(path: Path, fm: dict, tier: str = TIER_STANDARD) -> Tup
     return errors, warnings, infos
 
 
+# Load-time shell substitution, the two documented forms:
+#   !`command`   inline substitution
+#   ```!         a fenced block whose body is executed
+RE_INLINE_SHELL = re.compile(r"!`([^`\n]+)`")
+RE_SHELL_FENCE = re.compile(r"^\s*```!")
+RE_ANY_FENCE = re.compile(r"^\s*(```|~~~)")
+
+
+def _load_time_shell_hits(body: str, line_offset: int = 0) -> List[str]:
+    """Locations of load-time shell substitution, as 'L<line>: <snippet>'.
+
+    Occurrences inside an ordinary code fence are excluded (skills that
+    document the syntax). The ```! fence is itself the executable form, so
+    it is always counted. `line_offset` shifts reported lines into file
+    coordinates when frontmatter was already stripped.
+    """
+    hits: List[str] = []
+    in_fence = False
+    for i, line in enumerate(body.splitlines(), start=1 + line_offset):
+        if RE_SHELL_FENCE.match(line):
+            hits.append(f"L{i}: ```! block")
+            in_fence = not in_fence
+            continue
+        if RE_ANY_FENCE.match(line):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        for m in RE_INLINE_SHELL.finditer(line):
+            cmd = m.group(1).strip()
+            hits.append(f"L{i}: !`{cmd[:40]}{'…' if len(cmd) > 40 else ''}`")
+    return hits
+
+
 def validate_body(
-    path: Path, body: str, tier: str = TIER_STANDARD, fm: dict = None
+    path: Path, body: str, tier: str = TIER_STANDARD, fm: dict = None, line_offset: int = 0
 ) -> Tuple[List[str], List[str], List[str]]:
     """
     Validate SKILL.md body content.
@@ -3049,6 +3096,22 @@ def validate_body(
     if fm is None:
         fm = {}
     lines = body.splitlines()
+
+    # === LOAD-TIME SHELL EXECUTION (schema 3.16.1) — advisory only ===
+    # Preprocessing, not a tool call; allowed-tools does not gate it.
+    shell_hits = _load_time_shell_hits(body, line_offset)
+    if shell_hits:
+        where = ", ".join(shell_hits[:3]) + (
+            f" (+{len(shell_hits) - 3} more)" if len(shell_hits) > 3 else ""
+        )
+        target = fm.get("shell")
+        target_note = f"; `shell: {target}` selects the interpreter" if target else ""
+        warnings.append(
+            f"[security] SKILL.md runs {len(shell_hits)} shell substitution(s) at LOAD time, before Claude "
+            f"reads the body: {where}. This is preprocessing — it is not a tool call, allowed-tools does not "
+            f"gate it, and the output is not re-scanned{target_note}. Review it as executable code. The "
+            f"documented kill switch is the `disableSkillShellExecution` setting."
+        )
 
     # === LENGTH CHECKS ===
 

--- a/tests/test_validate_skills_schema_frontmatter.py
+++ b/tests/test_validate_skills_schema_frontmatter.py
@@ -439,3 +439,82 @@ def test_disallowed_tools_bad_shape_is_error():
     }
     errors, _warnings, _infos = _frontmatter(fm, validator.TIER_STANDARD)
     assert any("'disallowed-tools' must be" in e for e in errors), errors
+
+
+# =========================================================================
+# schema 3.16.1 — security lane (load-time shell + disallowed-tools entries)
+# Residual of closed PR #1113; re-cut cleanly on main after VALID_TOOLS 3.16.0.
+# =========================================================================
+
+SHELL_SKILL = """---
+name: my-skill
+description: Validate skill frontmatter fields against the published schema registry.
+---
+
+# Body
+
+!`git status`
+"""
+
+
+def test_load_time_shell_substitution_is_reported():
+    hits = validator._load_time_shell_hits("a\n!`git status`\nb")
+    assert len(hits) == 1, hits
+    assert "git status" in hits[0]
+
+
+def test_shell_hits_are_reported_in_file_line_numbers():
+    """A security finding pointing at the wrong line is worse than none."""
+    body = "x\n!`whoami`\n"
+    assert validator._load_time_shell_hits(body)[0].startswith("L2:")
+    assert validator._load_time_shell_hits(body, line_offset=10)[0].startswith("L12:")
+
+
+def test_shell_syntax_inside_an_ordinary_fence_is_not_a_finding():
+    """Skills that DOCUMENT the syntax must not be flagged as executing it."""
+    body = "```\n!`git status`\n```\n"
+    assert validator._load_time_shell_hits(body) == []
+
+
+def test_shell_fence_form_is_always_counted():
+    hits = validator._load_time_shell_hits("```!\necho hi\n```\n")
+    assert any("```! block" in h for h in hits), hits
+
+
+def test_body_check_surfaces_shell_execution_as_a_warning_not_an_error():
+    errors, warnings, _ = validator.validate_body(
+        SKILL_PATH, SHELL_SKILL.split("---", 2)[2], validator.TIER_MARKETPLACE, {"name": "my-skill"}
+    )
+    assert any("LOAD time" in w for w in warnings), warnings
+    assert not any("LOAD time" in e for e in errors), errors
+
+
+def test_disallowed_tools_entries_are_validated():
+    """A deny rule naming a non-existent tool denies nothing."""
+    fm = {"name": "my-skill", "description": GOOD_DESC, "disallowed-tools": "Wibble"}
+    _, warnings, _ = _frontmatter(fm, validator.TIER_MARKETPLACE)
+    assert any("disallowed-tools" in w and "Wibble" in w for w in warnings), warnings
+
+
+def test_disallowed_tools_flags_the_legacy_name():
+    fm = {"name": "my-skill", "description": GOOD_DESC, "disallowed-tools": "Task"}
+    _, warnings, _ = _frontmatter(fm, validator.TIER_MARKETPLACE)
+    assert any("disallowed-tools" in w and ("Legacy" in w or "Task" in w) for w in warnings), warnings
+
+
+def test_disallowed_tools_overlap_error_still_fires():
+    """Regression guard: entry validation must not displace the overlap rule."""
+    fm = {
+        "name": "my-skill",
+        "description": GOOD_DESC,
+        "allowed-tools": "Read",
+        "disallowed-tools": "Read",
+    }
+    errors, _, _ = _frontmatter(fm, validator.TIER_MARKETPLACE)
+    assert any("contradictory" in e for e in errors), errors
+
+
+def test_clean_disallowed_tools_is_quiet():
+    fm = {"name": "my-skill", "description": GOOD_DESC, "disallowed-tools": "Bash(rm:*), Agent"}
+    _, warnings, _ = _frontmatter(fm, validator.TIER_MARKETPLACE)
+    assert not any("disallowed-tools" in w for w in warnings), warnings

--- a/tests/test_validate_skills_schema_frontmatter.py
+++ b/tests/test_validate_skills_schema_frontmatter.py
@@ -384,7 +384,8 @@ def test_843_end_to_end_validate_agent_surfaces_check3(tmp_path):
 
 def test_allowed_disallowed_tool_overlap_is_error():
     fm = {
-        "name": "my-skill", "description": GOOD_DESC,
+        "name": "my-skill",
+        "description": GOOD_DESC,
         "allowed-tools": "Read, Bash(rm:*)",
         "disallowed-tools": "Bash(rm:*)",
     }
@@ -394,7 +395,8 @@ def test_allowed_disallowed_tool_overlap_is_error():
 
 def test_overlap_is_error_at_marketplace_tier_too():
     fm = {
-        "name": "my-skill", "description": GOOD_DESC,
+        "name": "my-skill",
+        "description": GOOD_DESC,
         "allowed-tools": ["Read", "Write"],
         "disallowed-tools": ["Write"],
     }
@@ -405,7 +407,8 @@ def test_overlap_is_error_at_marketplace_tier_too():
 def test_disjoint_allowed_disallowed_is_clean():
     # Defense-in-depth: disallow a tool NOT in allowed-tools (the intended use).
     fm = {
-        "name": "my-skill", "description": GOOD_DESC,
+        "name": "my-skill",
+        "description": GOOD_DESC,
         "allowed-tools": "Read, Write",
         "disallowed-tools": "Bash(rm:*), Bash(curl:*)",
     }
@@ -417,7 +420,8 @@ def test_overlap_detection_uses_shared_normalization():
     # Space-separated allowed-tools vs the same token in disallowed-tools must
     # still overlap — both go through parse_allowed_tools().
     fm = {
-        "name": "my-skill", "description": GOOD_DESC,
+        "name": "my-skill",
+        "description": GOOD_DESC,
         "allowed-tools": "Read Bash(rm:*)",
         "disallowed-tools": ["Bash(rm:*)"],
     }
@@ -434,8 +438,10 @@ def test_disallowed_tools_without_allowed_tools_is_clean():
 
 def test_disallowed_tools_bad_shape_is_error():
     fm = {
-        "name": "my-skill", "description": GOOD_DESC,
-        "allowed-tools": "Read", "disallowed-tools": 123,
+        "name": "my-skill",
+        "description": GOOD_DESC,
+        "allowed-tools": "Read",
+        "disallowed-tools": 123,
     }
     errors, _warnings, _infos = _frontmatter(fm, validator.TIER_STANDARD)
     assert any("'disallowed-tools' must be" in e for e in errors), errors


### PR DESCRIPTION
## What

1. **Validator schema 3.16.1 security lane** (residual of closed #1113):
   - Load-time shell substitution findings (`` !`cmd` `` / ` ```! `) as advisory `[security]` warnings
   - `disallowed-tools` entry validation (no more silent broken deny lists)
2. **walkie-talkie** marketplace frontmatter + body sections → **B 87/100** (Closes #1112)

[skip auto-bump]

## Why

#1113 was closed because VALID_TOOLS was already on main; security lane needed a clean re-cut. Walkie-talkie was C/72 from missing required fields.

## Verification

- `pytest tests/test_validate_skills_schema_frontmatter.py` — 49 passed
- `validate-skills-schema.py --marketplace plugins/community/walkie-talkie/SKILL.md` — Grade B 87/100

## Risk

Advisory-only — will not fail marketplace merges on existing shell skills; surfaces reviewable findings.