### PR TITLE
fix(ci): quiet failed prescreen LLM summaries

### DIFF
--- a/.github/workflows/pr-prescreen.yml
+++ b/.github/workflows/pr-prescreen.yml
@@ -264,21 +264,22 @@ jobs:
           echo "=== verdict ===" >&2
           jq . /tmp/verdict.json >&2
 
-      # Groq LLM screener — advisory, never blocking. Single attempt, 5s
+      # DeepSeek LLM summary — advisory, never blocking. Single attempt, 5s
       # deadline. Any failure (missing key, non-2xx, timeout, malformed
-      # response) leaves /tmp/verdict.json untouched-but-augmented with a
-      # deterministic fallback summary and an llm_status field. The Groq
+      # response) leaves /tmp/verdict.json augmented only with a diagnostic
+      # llm_status field; reviewer-facing notifications continue to show the
+      # deterministic classifier output without provider-failure noise. The LLM
       # call is contained: it sees the validator's JSON output, NOT the
       # PR diff or any PR-controlled text.
       - name: DeepSeek LLM summary
-        id: groq
+        id: llm-summary
         continue-on-error: true
         env:
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
         run: |
           set -euo pipefail
-          mv /tmp/verdict.json /tmp/verdict.pre-groq.json
-          python3 base/scripts/pr-prescreen/summarize.py /tmp/verdict.pre-groq.json \
+          mv /tmp/verdict.json /tmp/verdict.pre-llm.json
+          python3 base/scripts/pr-prescreen/summarize.py /tmp/verdict.pre-llm.json \
             > /tmp/verdict.json
           jq -r '.llm_status // "unknown"' /tmp/verdict.json >&2
           jq -r '.summary_lines // ""' /tmp/verdict.json >&2
@@ -436,10 +437,10 @@ jobs:
           PR_URL="https://github.com/${REPO}/pull/${PR_NUMBER}"
           # Read blockers (if HARD_BLOCK) for inline display.
           BLOCKERS=$(jq -r 'if .blockers and (.blockers|length>0) then "Blockers: " + (.blockers | join(", ")) else "" end' /tmp/verdict.json)
-          GROQ_LINES=$(jq -r '.summary_lines // ""' /tmp/verdict.json)
+          LLM_LINES=$(jq -r '.summary_lines // ""' /tmp/verdict.json)
           TEXT="${ICON} PR #${PR_NUMBER} from @${PR_AUTHOR} — *${VERDICT}*\n${PR_TITLE}\n${SUMMARY}"
-          if [ -n "$GROQ_LINES" ]; then
-            TEXT="${TEXT}\n\`\`\`\n${GROQ_LINES}\n\`\`\`"
+          if [ -n "$LLM_LINES" ]; then
+            TEXT="${TEXT}\n\`\`\`\n${LLM_LINES}\n\`\`\`"
           fi
           if [ -n "$BLOCKERS" ]; then
             TEXT="${TEXT}\n${BLOCKERS}"

--- a/scripts/pr-prescreen/summarize.py
+++ b/scripts/pr-prescreen/summarize.py
@@ -3,9 +3,10 @@
 Reads the classifier output produced by classify.py and asks an
 OpenAI-compatible chat API (DeepSeek by default) for a ≤5-line human
 summary. Returns the original classifier output with an added
-"summary_lines" key on success, or a "summary_lines" key set to a
-single fallback line + an "llm_status" key indicating why the LLM call
-was skipped or failed.
+"summary_lines" key on success. When the optional LLM is unavailable,
+the output keeps only the machine-readable "llm_status" diagnostic;
+reviewer-facing consumers already render the deterministic classifier
+summary and must not repeat provider failures as notification noise.
 
 Constraints:
 - Single attempt. No retries. 5-second wall-clock deadline.
@@ -107,19 +108,6 @@ def call_llm(classifier_output: dict, *, api_key: str, api_url: str, model: str,
     return content
 
 
-def _fallback_summary(classifier_output: dict, reason: str) -> str:
-    verdict = classifier_output.get("verdict", "PASS")
-    summary = classifier_output.get("summary", "")
-    icon = {"PASS": "✅", "CHANGES_REQUESTED": "⚠️", "HARD_BLOCK": "🛑"}.get(verdict, "•")
-    return (
-        f"{icon} {verdict}\n"
-        f"{summary}\n"
-        f"LLM screener unavailable: {reason}.\n"
-        "Falling back to deterministic validator output only.\n"
-        "See per-skill table below for full detail."
-    )
-
-
 def normalise_summary_lines(text: str) -> str:
     """Trim to 5 lines, strip stray markdown fences, no trailing whitespace."""
     lines = [l.rstrip() for l in text.splitlines() if l.strip()]
@@ -135,11 +123,13 @@ def normalise_summary_lines(text: str) -> str:
 
 
 def summarize(classifier_output: dict) -> dict:
-    """Augment classifier output with an LLM summary or fallback explanation."""
+    """Augment classifier output with an LLM summary or a quiet status diagnostic."""
     out = dict(classifier_output)
+    # Never propagate a caller-supplied/stale summary into notifications when
+    # this invocation cannot produce a successful LLM result.
+    out.pop("summary_lines", None)
     api_key = os.environ.get("DEEPSEEK_API_KEY", "").strip()
     if not api_key:
-        out["summary_lines"] = _fallback_summary(out, "DEEPSEEK_API_KEY not set")
         out["llm_status"] = "skipped: no api key"
         return out
 
@@ -153,7 +143,6 @@ def summarize(classifier_output: dict) -> dict:
     try:
         raw = call_llm(out, api_key=api_key, api_url=api_url, model=model, timeout=timeout)
     except urllib.error.HTTPError as exc:
-        out["summary_lines"] = _fallback_summary(out, f"LLM HTTP {exc.code}")
         out["llm_status"] = f"failed: http {exc.code}"
         return out
     except Exception as exc:
@@ -163,7 +152,6 @@ def summarize(classifier_output: dict) -> dict:
         # deterministic fallback, not propagate and kill the workflow.
         # Also avoids the Python 3.11 TimeoutError-builtin issue on
         # older runners.
-        out["summary_lines"] = _fallback_summary(out, str(exc) or exc.__class__.__name__)
         out["llm_status"] = f"failed: {exc.__class__.__name__}"
         return out
 

--- a/scripts/pr-prescreen/test_summarize.py
+++ b/scripts/pr-prescreen/test_summarize.py
@@ -48,12 +48,11 @@ class _FakeResp:
 
 
 class SummarizeTests(unittest.TestCase):
-    def test_no_api_key_falls_back(self):
+    def test_no_api_key_records_status_without_reviewer_summary(self):
         with patch.dict(os.environ, {"DEEPSEEK_API_KEY": ""}, clear=False):
             out = summarize.summarize(SAMPLE_CLASSIFIER_OUT)
         self.assertEqual(out["llm_status"], "skipped: no api key")
-        self.assertIn("LLM screener unavailable", out["summary_lines"])
-        self.assertIn("CHANGES_REQUESTED", out["summary_lines"])
+        self.assertNotIn("summary_lines", out)
 
     def test_happy_path_includes_summary_lines(self):
         canned = (
@@ -72,7 +71,7 @@ class SummarizeTests(unittest.TestCase):
         self.assertEqual(len(out["summary_lines"].splitlines()), 5)
         self.assertIn("CHANGES_REQUESTED", out["summary_lines"])
 
-    def test_groq_http_error_falls_back(self):
+    def test_deepseek_http_error_records_status_without_reviewer_summary(self):
         err = urllib.error.HTTPError(summarize.DEFAULT_API_URL, 503, "service unavailable", {}, None)
         with (
             patch.dict(os.environ, {"DEEPSEEK_API_KEY": "test"}),
@@ -80,7 +79,7 @@ class SummarizeTests(unittest.TestCase):
         ):
             out = summarize.summarize(SAMPLE_CLASSIFIER_OUT)
         self.assertEqual(out["llm_status"], "failed: http 503")
-        self.assertIn("LLM screener unavailable", out["summary_lines"])
+        self.assertNotIn("summary_lines", out)
 
     def test_timeout_falls_back(self):
         # OSError covers timeouts across Python versions (TimeoutError is a
@@ -92,7 +91,13 @@ class SummarizeTests(unittest.TestCase):
         ):
             out = summarize.summarize(SAMPLE_CLASSIFIER_OUT)
         self.assertTrue(out["llm_status"].startswith("failed:"))
-        self.assertIn("LLM screener unavailable", out["summary_lines"])
+        self.assertNotIn("summary_lines", out)
+
+    def test_failure_drops_stale_input_summary(self):
+        stale = dict(SAMPLE_CLASSIFIER_OUT, summary_lines="stale provider output")
+        with patch.dict(os.environ, {"DEEPSEEK_API_KEY": ""}, clear=False):
+            out = summarize.summarize(stale)
+        self.assertNotIn("summary_lines", out)
 
     def test_unexpected_exception_falls_back(self):
         # Regression for the "never block" contract: even an unforeseen


### PR DESCRIPTION
Closes #1122.

Failed or skipped optional LLM calls now retain `llm_status` for logs, JSON, and audit without adding fallback text to PR comments or Slack. Deterministic verdicts, blockers, warnings, and per-skill results remain visible. Stale Groq workflow labels were aligned with the configured DeepSeek summary step.

Bead: `claude-yt7i`

Validation:
- `python3 -m unittest discover -s scripts/pr-prescreen -p "test_*.py"` (27 tests)
- Ruff lint and format
- actionlint
- `git diff --check`

Local `yamllint` was unavailable; CI supplies that check.