### PR TITLE
fix(ci): filter redundant automated reviews

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -4,7 +4,19 @@
     "logic",
     "syntax"
   ],
-  "triggerOnUpdates": true,
+  "triggerOnUpdates": false,
+  "triggerOnDrafts": false,
+  "disabledLabels": [
+    "automated",
+    "generated",
+    "skip-greptile",
+    "no-ai-review"
+  ],
+  "excludeAuthors": [
+    "dependabot[bot]",
+    "renovate[bot]"
+  ],
+  "ignoreKeywords": "[skip greptile]\n[skip ai review]\nDaily npm download stats refresh",
   "fixWithAI": true,
   "confidenceScoreSection": {
     "included": true
@@ -12,7 +24,7 @@
   "sequenceDiagramSection": {
     "included": true
   },
-  "ignorePatterns": "node_modules/\n.venv/\ndist/\nbuild/\ncoverage/\nmarketplace/dist/\nmarketplace/.astro/\nmarketplace/public/downloads/\npnpm-lock.yaml\npackage-lock.json\n*.min.js\n.claude-plugin/marketplace.json\nfreshie/inventory.sqlite",
+  "ignorePatterns": "node_modules/\n.venv/\ndist/\nbuild/\ncoverage/\nmarketplace/dist/\nmarketplace/.astro/\nmarketplace/public/downloads/\npnpm-lock.yaml\npackage-lock.json\n*.min.js\n.claude-plugin/marketplace.json\nfreshie/inventory.sqlite\nmarketplace/src/data/npm-stats.json",
   "rules": [
     {
       "id": "no-gate-weakening",


### PR DESCRIPTION
## Summary

- disable automatic re-reviews on every PR update
- keep draft PRs out of automatic review
- skip dependency bots and explicit opt-out labels/keywords
- skip known high-volume automation: `Daily npm download stats refresh`
- ignore generated artifacts when mixed into otherwise reviewable PRs

## Evidence

Greptile API audit of the latest 100 review runs found only 40 unique PRs. Individual PRs were reviewed 4–9 times; this repository currently had `triggerOnUpdates: true`.

Tracked by Beads: `startaitools-r26`.

## Validation

- JSON parsed and re-serialized successfully
- existing strictness, comment categories, context rules, and substantive-code coverage are preserved