### PR TITLE
feat(ci): add a cascading Greptile config validator and reactivate Greptile as advisory

### DIFF
--- a/.github/workflows/.greptile/config.json
+++ b/.github/workflows/.greptile/config.json
@@ -1,0 +1,34 @@
+{
+  "rules": [
+    {
+      "id": "ci-required-always-reports",
+      "severity": "high",
+      "scope": ["*.yml", "*.yaml"],
+      "rule": "Branch protection requires exactly the always-reporting `ci-required`, `gitleaks`, and `skill-conform` contexts. `validate-plugins.yml` must run on every pull_request without a paths filter; `ci-required` must use `if: always()` and may depend only on jobs that always report or have an explicitly designed skip. Never add a path-scoped, provider-dependent, secret-dependent, or advisory job to its `needs:`. `skill-conform` remains its own required context; behavioral eval, kernel soak, MCP validation, CodeQL's scoped lane, and AI review remain outside the aggregate unless their documented graduation process is completed."
+    },
+    {
+      "id": "pull-request-target-base-code-only",
+      "severity": "high",
+      "scope": ["*.yml", "*.yaml"],
+      "rule": "A `pull_request_target` job has secrets and MUST NOT execute PR-authored code, scripts, actions, package installs, or workflow commands. Pin the PR checkout by head SHA with credentials disabled and treat it as read-only data. Execute base-authored tooling only. For the pre-screen, preserve the deliberate copy of the base-authored validator into the PR tree: the validator anchors its scan root to its own file location, so running it from the base tree false-PASSes PR changes."
+    },
+    {
+      "id": "automation-must-converge",
+      "severity": "high",
+      "scope": ["*.yml", "*.yaml"],
+      "rule": "Writer workflows and PR bots must converge under synchronize, rerun, and schedule events. Version automation compares the declared value to the PR base and bumps at most once; new plugins and already-ahead manual bumps do not re-bump. PR-existence checks query OPEN PRs only, not merged/closed history. A bot push must not leave a head commit with required contexts that can never report. Flag loops, force-push churn, stale-reader branches, and non-idempotent comment/PR creation."
+    },
+    {
+      "id": "deterministic-verdicts-fail-closed",
+      "severity": "high",
+      "scope": ["*.yml", "*.yaml"],
+      "rule": "A validator crash, empty impossible result set, missing output, malformed JSON, or partial sync must never be classified as PASS. Optional LLM summaries may fail quietly but cannot alter, replace, or paste failure text into the deterministic verdict. Any `|| true` or `continue-on-error` around a verdict producer must preserve and inspect the exit/result explicitly and surface an internal-error state."
+    },
+    {
+      "id": "workflow-command-channel-safety",
+      "severity": "medium",
+      "scope": ["*.yml", "*.yaml"],
+      "rule": "Values derived from PRs, validators, APIs, or generated reports must enter shell through environment variables or files, never direct `${{ }}` interpolation into executable script text. Multiline `$GITHUB_OUTPUT`/`$GITHUB_ENV` writes require a collision-resistant delimiter and a guaranteed newline before the closing delimiter. Preserve `set -euo pipefail` unless a step documents and handles each non-zero exit deliberately."
+    }
+  ]
+}

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -190,6 +190,11 @@ jobs:
       - name: Validate design-token discipline (DESIGN.md color rules)
         run: node scripts/lint-design-tokens.mjs
 
+      - name: Validate cascading Greptile configuration
+        run: |
+          node --test scripts/validate-greptile-config.test.mjs
+          pnpm run validate:greptile
+
       - name: Check plugin structure
         run: |
           echo "Checking plugin structure..."

--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -18,13 +18,26 @@
   ],
   "ignoreKeywords": "[skip greptile]\n[skip ai review]\nDaily npm download stats refresh",
   "fixWithAI": true,
+  "statusCheck": false,
+  "updateExistingSummaryComment": true,
+  "context": {
+    "repos": [
+      "jeremylongshore/intent-audit-harness",
+      "jeremylongshore/intent-eval-core",
+      "jeremylongshore/intent-eval-dashboard",
+      "jeremylongshore/intent-eval-lab",
+      "jeremylongshore/intent-rollout-gate",
+      "jeremylongshore/j-rig-skill-binary-eval"
+    ]
+  },
+  "instructions": "Review this repository as executable agent infrastructure, a public plugin supply chain, and a generated marketplace. Prioritize semantic correctness, security boundaries, authority/source-of-truth violations, fail-open behavior, data-integrity drift, and install/runtime breakage. Do not repeat formatter, linter, typechecker, schema, or generated-drift findings already emitted by required CI unless the diff weakens or bypasses that gate. Use the Intent Eval context repositories when a change touches authoring contracts, Evidence Bundles, deterministic gates, behavioral evaluation, rollout decisions, or dashboard evidence rendering.",
   "confidenceScoreSection": {
     "included": true
   },
   "sequenceDiagramSection": {
-    "included": true
+    "included": false
   },
-  "ignorePatterns": "node_modules/\n.venv/\ndist/\nbuild/\ncoverage/\nmarketplace/dist/\nmarketplace/.astro/\nmarketplace/public/downloads/\npnpm-lock.yaml\npackage-lock.json\n*.min.js\n.claude-plugin/marketplace.json\nfreshie/inventory.sqlite\nmarketplace/src/data/npm-stats.json",
+  "ignorePatterns": "node_modules/\n.venv/\ndist/\nbuild/\ncoverage/\nmarketplace/dist/\nmarketplace/.astro/\nmarketplace/public/downloads/\nskills/.curated/\npnpm-lock.yaml\npackage-lock.json\nyarn.lock\nbun.lock\nbun.lockb\n**/*.min.js\n**/*.map\n**/*.snap\n.claude-plugin/marketplace.json\nfreshie/inventory.sqlite\nmarketplace/src/data/npm-stats.json",
   "rules": [
     {
       "id": "no-gate-weakening",
@@ -51,9 +64,9 @@
       "rule": "The IS 8-field ALWAYS_REQUIRED set (name, description, allowed-tools, version, author, license, compatibility, tags) is authoritative; at marketplace tier a missing required field is an ERROR, not a warning. Do not suggest reducing the required set, demoting marketplace errors to warnings, or realigning to Anthropic's permissive floor. Changes to required-fields / tier model / error-vs-warning semantics are approval-gated (see SCHEMA_CHANGELOG NON-NEGOTIABLES)."
     },
     {
-      "id": "kernel-pin-frozen-during-soak",
+      "id": "kernel-authority-frozen-during-soak",
       "severity": "high",
-      "rule": "The `@intentsolutions/core` kernel pin is frozen at an exact version (no ^/~) during the validator-cutover soak. Do not suggest bumping it, and do not suggest flipping the kernel-shadow or kernel-vendor-hash CI lanes from advisory (continue-on-error) to blocking — that promotion is gated by a separate documented checklist, not a code change."
+      "rule": "Keep the `@intentsolutions/core` pin exact (no ^/~) and current with the published kernel; a routine exact-version bump is allowed and is separate from authority. The prose validator remains authoritative, while kernel-shadow and kernel-vendor-hash stay advisory until every documented soak/cutover condition and governance approval is met. Flag any PR that conflates a pin update with promoting kernel authority, changes the byte-frozen authoring/v1 contract locally, or makes either shadow lane blocking as a side effect."
     },
     {
       "id": "agent-vs-skill-tool-fields",
@@ -91,7 +104,7 @@
     {
       "id": "no-generated-artifacts-committed",
       "severity": "medium",
-      "rule": "Do not commit generated artifacts: marketplace/public/downloads/ (gitignored, rebuilt in CI from the catalog), marketplace/dist/, or the derived .claude-plugin/marketplace.json. CI rebuilds these from source; committing them leaks local state to prod."
+      "rule": "Do not commit ephemeral build artifacts such as marketplace/public/downloads/ or marketplace/dist/. The derived `.claude-plugin/marketplace.json`, generated plugin package.json files, and README AUTO-TOC are tracked outputs: they MUST be regenerated from `.claude-plugin/marketplace.extended.json` with `pnpm run sync-marketplace` and committed when the source changes, but never hand-edited. Fix drift at the authoritative source or generator, not in a derived copy."
     },
     {
       "id": "sources-yaml-is-a-pointer",

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -10,23 +10,115 @@
     },
     {
       "path": "000-docs/SCHEMA_CHANGELOG.md",
-      "description": "The NON-NEGOTIABLES: the 8-field ALWAYS_REQUIRED set, marketplace-tier error-vs-warning semantics, and which changes are approval-gated."
+      "description": "The NON-NEGOTIABLES: the 8-field ALWAYS_REQUIRED set, marketplace-tier error-vs-warning semantics, and which changes are approval-gated.",
+      "scope": [
+        "scripts/validate-skills-schema.py",
+        "plugins/**/SKILL.md",
+        "plugins/**/agents/*.md",
+        ".github/workflows/kernel-*.yml"
+      ]
     },
     {
       "path": "scripts/validate-skills-schema.py",
-      "description": "The authoritative prose-spec validator — the canonical merge gate for frontmatter and markdown body sections, plus the kernel-strict agent gate."
+      "description": "The authoritative prose-spec validator — the canonical merge gate for frontmatter and markdown body sections, plus the kernel-strict agent gate.",
+      "scope": [
+        "scripts/validate-skills-schema.py",
+        "scripts/pr-prescreen/**",
+        "plugins/**/SKILL.md",
+        "plugins/**/agents/*.md"
+      ]
     },
     {
       "path": ".github/workflows/validate-plugins.yml",
-      "description": "The CI gate definitions: plugin structure, catalog invariants, README-TOC sync, and the lint/test matrix."
+      "description": "The unfiltered required aggregate: plugin structure, catalog invariants, README-TOC sync, and the lint/test matrix.",
+      "scope": [".github/workflows/**", "scripts/ci/**"]
     },
     {
       "path": "marketplace/DESIGN.md",
-      "description": "The marketplace design constitution — OKLCH-only colors, the Data-Dense Pro family, and explicitly rejected UI patterns."
+      "description": "The marketplace design constitution — OKLCH-only colors, the Data-Dense Pro family, and explicitly rejected UI patterns.",
+      "scope": ["marketplace/**"]
     },
     {
       "path": "000-docs/6767-b-SPEC-DR-STND-claude-skills-standard.md",
-      "description": "The IS enterprise / marketplace skills standard (v3.x) that the validator enforces."
+      "description": "The IS enterprise / marketplace skills standard (v3.x) that the validator enforces.",
+      "scope": [
+        "plugins/**/SKILL.md",
+        "plugins/**/agents/*.md",
+        "scripts/validate-skills-schema.py"
+      ]
+    },
+    {
+      "path": "000-docs/265-DR-GUID-pr-prescreen-system.md",
+      "description": "Operator contract for the advisory pull_request_target pre-screen, including base-authored execution and deterministic-verdict boundaries.",
+      "scope": [".github/workflows/pr-prescreen.yml", "scripts/pr-prescreen/**"]
+    },
+    {
+      "path": "000-docs/690-AT-APIS-6767h-to-kernel-authoring-v1-mapping-2026-06-11.md",
+      "description": "Field-level prose-validator to kernel authoring/v1 mapping, intentional deviations, and shadow-only migration posture.",
+      "scope": [
+        "scripts/validate-skills-schema.py",
+        "scripts/kernel-shadow-validation.mjs",
+        ".github/workflows/kernel-*.yml",
+        "package.json"
+      ]
+    },
+    {
+      "path": "000-docs/694-AT-DECR-external-sync-mirror-by-default-model.md",
+      "description": "Locked mirror-by-default, upstream-improvements, never-clobber authority model for externally synced plugins.",
+      "scope": [
+        "sources.yaml",
+        "sources.lock.json",
+        "scripts/sync-*.mjs",
+        ".github/workflows/sync-external.yml",
+        "plugins/community/**"
+      ]
+    },
+    {
+      "path": "000-docs/698-TQ-SECU-external-sync-threat-model.md",
+      "description": "Supply-chain threat model for synced instructions, scripts, hooks, MCP servers, lock/quarantine, and REFUSE/CHALLENGE/FLAG semantics.",
+      "scope": [
+        "sources.yaml",
+        "sources.lock.json",
+        "scripts/scan-*.mjs",
+        "scripts/sync-*.mjs",
+        "plugins/community/**",
+        "plugins/mcp/**"
+      ]
+    },
+    {
+      "path": "000-docs/699-DR-GUID-external-source-vetting-playbook.md",
+      "description": "Human vetting and approval procedure that complements deterministic sync and scanner gates.",
+      "scope": [
+        "sources.yaml",
+        "sources.lock.json",
+        "scripts/scan-allowlist.txt",
+        "plugins/community/**"
+      ]
+    },
+    {
+      "path": "000-docs/700-DR-GUID-skill-submission-standard.md",
+      "description": "Issue-before-PR and tiered PRD/ADR/ONE-PAGER proof requirements for new authored plugins.",
+      "scope": ["plugins/**/.claude-plugin/plugin.json", "plugins/**/docs/**"]
+    },
+    {
+      "path": "000-docs/008-TQ-SECU-security.md",
+      "description": "Repository security policy and disclosure boundary for plugin supply-chain findings.",
+      "scope": ["plugins/**", "scripts/**", ".github/workflows/**"]
+    },
+    {
+      "path": "sources.yaml",
+      "description": "External source registry; use it to evaluate verified/curated semantics, anchored include breadth, target ownership, and provenance.",
+      "scope": ["sources.yaml", "sources.lock.json", "scripts/sync-*.mjs", "plugins/community/**"]
+    },
+    {
+      "path": "freshie/README.md",
+      "description": "Freshie SQLite runtime, one-way Dolt history, exporter, proof tables, and restore/operating contract.",
+      "scope": ["freshie/**"]
+    },
+    {
+      "path": "RELEASING.md",
+      "description": "Published package version, tag, release, and automated publish contract.",
+      "scope": ["packages/**", ".github/workflows/publish-*.yml", "package.json"]
     }
   ]
 }

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -9,7 +9,7 @@ This repo is the **Tons of Skills** marketplace for Claude Code plugins and skil
 ## Architecture you must respect
 
 - **Two-catalog system.** `.claude-plugin/marketplace.extended.json` is the **source of truth** (edit this). `.claude-plugin/marketplace.json` is **auto-generated** by `pnpm run sync-marketplace` — never hand-edit it; CI's drift gate rejects divergence. The same step generates plugin `package.json`s and the README AUTO-TOC block.
-- **The prose-spec validator is authoritative.** `scripts/validate-skills-schema.py` is the canonical gate. The `@intentsolutions/core` kernel is the SSoT being migrated to, currently in an **advisory soak** — do not promote the kernel CI lanes from advisory to blocking, and do not bump the frozen kernel pin.
+- **The prose-spec validator is authoritative.** `scripts/validate-skills-schema.py` is the canonical gate. The `@intentsolutions/core` kernel is the SSoT being migrated to, currently in an **advisory soak**. Keep its pin exact and current, but do not treat a pin bump as an authority flip or promote the kernel CI lanes from advisory to blocking before the documented cutover gates pass.
 - **External-sync pipeline.** `sources.yaml` + `scripts/sync-external.mjs` mirror external plugin repos into `plugins/`; synced plugins carry a `.source.json` marker.
 - **Package managers:** pnpm everywhere **except `marketplace/` (npm)**, CI-enforced. Node >= 20 (Node 18 breaks workspace resolution).
 
@@ -29,7 +29,16 @@ This repo is the **Tons of Skills** marketplace for Claude Code plugins and skil
 
 ## Related repos (multi-repo context)
 
-This repo depends on **`@intentsolutions/core`** (the authoring-schema kernel SSoT — a separate package/repo) and follows the deployment authority in **`intent-solutions-io/intent-os/ops/deploy`**. Greptile's current config schema does not expose a multi-repo `patternRepositories` key, so these are noted here for reviewer context rather than wired into `config.json`.
+The root config attaches the six-repository Intent Eval Platform cluster as read-only context:
+
+- `intent-eval-core` owns shared authoring contracts, schemas, validators, and Evidence Bundle shapes.
+- `intent-eval-lab` owns methodology, Blueprints, binding Decision Records, and governance rationale.
+- `intent-audit-harness` owns deterministic gates and their Evidence Bundle emission.
+- `j-rig-skill-binary-eval` owns behavioral evaluation, judge independence, and rollout decision logic.
+- `intent-rollout-gate` is the thin GitHub Action shell consuming the published decision package.
+- `intent-eval-dashboard` verifies and renders signed evidence.
+
+Use those repos when a CCPI change crosses one of those contracts. Do not demand cross-repo changes for ordinary catalog or marketplace work, and do not copy a kernel-owned schema or predicate into CCPI merely because the related repo is available as context.
 
 ## Reviewing a `sources.yaml` entry
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,9 +198,9 @@ Beyond the 8 required fields, schema 3.5.0+ adds optional visibility-gating fiel
 
 **Advisory lanes (report, never block — never promote into the required set from a side PR):** the two kernel lanes (next section); agent frontmatter (`validate-skills-schema.py --agents-only`, report-only with a tracked `REPORT-ONLY-UNTIL:` marker — corpus unbaselined); `.mcp.json` (`scripts/validate-mcp-config.mjs`, never `--strict` — that promotion belongs to the DR-049 soak checklist); CodeQL (PR trigger scoped to `packages/**` + `marketplace/src/**` so it adds no fan-out to plugin PRs); and the PR pre-screen (below).
 
-### AI review — both dark; CI is the only merge gate
+### AI review — Greptile is active and advisory; CI is the only merge gate
 
-**As of 2026-07-22 no AI reviewer is a reliable merge signal on this repo.** Gemini Code Assist consumer product is **sunset** (bot posts a sunset notice only; `.gemini/config.yaml` has `code_review.disable: true`). Greptile config remains under `.greptile/` but showed **zero activity** on recent IEP/CCPI PRs. Fully removing Apps is a UI/admin action. Optional future path: SHA-pinned MiniMax review (`MINIMAX_API_KEY` + `ENABLE_MINIMAX_REVIEW`) as already patterned in `minimax-review.yml`.
+**As of 2026-07-23 Greptile is active through the GitHub App and has reviewed recent CCPI PRs.** Its version-controlled policy lives under `.greptile/`; treat its findings as advisory semantic-review input, not a merge signal. Gemini Code Assist consumer product is **sunset** (bot posts a sunset notice only; `.gemini/config.yaml` has `code_review.disable: true`). Fully removing Apps is a UI/admin action. Optional future path: SHA-pinned MiniMax review (`MINIMAX_API_KEY` + `ENABLE_MINIMAX_REVIEW`) as already patterned in `minimax-review.yml`.
 
 **Operationally: never block a merge waiting for an AI review.** Required contexts are **`ci-required` + `gitleaks` + `skill-conform`**.
 

--- a/freshie/.greptile/config.json
+++ b/freshie/.greptile/config.json
@@ -1,0 +1,22 @@
+{
+  "rules": [
+    {
+      "id": "freshie-dolt-is-one-way-and-complete",
+      "severity": "high",
+      "scope": ["**"],
+      "rule": "`freshie/inventory.sqlite` is the untracked local runtime store; Dolt is versioned by the local exporter and pushed one-way to DoltHub. Never web-edit/merge remote Dolt data back, export an incomplete discovery run, hide a failed Dolt push, or let a live sql-server race the exporter. Public export is table-allowlisted and must not leak evaluator scratch/run tables."
+    },
+    {
+      "id": "freshie-proof-backed-status-only",
+      "severity": "high",
+      "scope": ["**"],
+      "rule": "Grades, JRig columns, curated promotion, run deltas, and verification badges require current recorded evidence. Missing local DB data must preserve the last committed proof artifact rather than erase it, while stale/ghost rows and stub badges must not be presented as current success. A discovery/remediation command must propagate child failures and stamp the run/commit it actually evaluated."
+    },
+    {
+      "id": "curated-skills-are-regenerated-mirrors",
+      "severity": "medium",
+      "scope": ["scripts/**", "grades.csv", "grade-histogram.json"],
+      "rule": "`skills/.curated` is regenerated from tracked grades and plugin sources, copies only tracked files, excludes external mirrors, and re-grades candidates before promotion. Fix source skills or promotion logic, not the mirror. Preserve manifest completeness and drop stale entries when their source no longer qualifies."
+    }
+  ]
+}

--- a/marketplace/.greptile/config.json
+++ b/marketplace/.greptile/config.json
@@ -1,0 +1,22 @@
+{
+  "rules": [
+    {
+      "id": "marketplace-build-has-one-way-data-flow",
+      "severity": "high",
+      "scope": ["**"],
+      "rule": "Marketplace data flows from authoritative catalog/plugin sources through the documented seven-step build into generated indexes, search data, cowork manifests/zips, and Astro output. Do not make generated data a competing source, commit downloads/dist, wire the slow cowork build into fast sync-marketplace, or remove the wipe+orphan validation that makes deploy `rsync --delete` safe."
+    },
+    {
+      "id": "marketplace-visible-claims-have-provenance",
+      "severity": "high",
+      "scope": ["src/**", "scripts/**", "*.md"],
+      "rule": "Visible counts, grades, verification badges, download statistics, pricing, and freshness timestamps must come from their named source and remain consistent across JSON, cards, README blocks, and detail pages. Preserve missing/no-data as missing instead of inventing zero, carry-forward, or a badge. Never present advisory, stale, or absent evidence as verified ground truth."
+    },
+    {
+      "id": "marketplace-client-actions-fire-once",
+      "severity": "medium",
+      "scope": ["src/**"],
+      "rule": "Navigation, install/copy/download actions, analytics, and redirects must fire once per user action across Chromium/WebKit and hydration boundaries. Flag double handlers, competing native+script navigation, non-idempotent mount effects, lost keyboard behavior, or optimistic UI that reports success before the underlying action succeeds."
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "pnpm --filter '*' test",
     "lint": "pnpm --filter '*' lint",
     "typecheck": "pnpm --filter '*' typecheck",
+    "validate:greptile": "node scripts/validate-greptile-config.mjs",
     "sync-marketplace": "node scripts/sync-marketplace.cjs && node scripts/generate-plugin-package-jsons.mjs && node scripts/generate-readme-toc.mjs",
     "sync-marketplace:json-only": "node scripts/sync-marketplace.cjs",
     "build-cowork": "node scripts/build-cowork-zips.mjs",

--- a/packages/.greptile/config.json
+++ b/packages/.greptile/config.json
@@ -1,0 +1,22 @@
+{
+  "rules": [
+    {
+      "id": "public-cli-contract-and-identifiers",
+      "severity": "high",
+      "scope": ["cli/**", "**/package.json"],
+      "rule": "CLI commands, flags, output/exit behavior, install coordinates, and catalog identifiers are public contracts. Preserve the canonical GitHub repo, `claude-code-plugins-plus` catalog id, and legacy public install slug. Flag silent breaking changes, wrong generated catalog selection, or a rename/migration without compatibility handling and user-facing release notes."
+    },
+    {
+      "id": "published-package-errors-are-honest",
+      "severity": "high",
+      "scope": ["**/src/**"],
+      "rule": "Published packages validate external inputs, distinguish missing/invalid/transport/internal errors, and never convert an exception or absent datum into a successful empty result. Keep side effects behind explicit commands and make retries/idempotency safe for package consumers. Behavior changes require focused regression tests at the public boundary."
+    },
+    {
+      "id": "intent-eval-pins-remain-compatible",
+      "severity": "high",
+      "scope": ["**/package.json", "**/src/**"],
+      "rule": "When packages consume Intent Eval contracts, reuse `@intentsolutions/core` rather than re-declaring schemas or predicate URIs. Exact core/j-rig pins and their peer ranges must resolve coherently; a pin update is allowed, but an authoring authority flip, Evidence Bundle shape change, or rollout/eval semantic change must be coordinated with the relevant Intent Eval context repository and its versioned contract."
+    }
+  ]
+}

--- a/plugins/.greptile/config.json
+++ b/plugins/.greptile/config.json
@@ -1,0 +1,40 @@
+{
+  "rules": [
+    {
+      "id": "skill-instructions-are-executable-supply-chain",
+      "severity": "high",
+      "scope": ["**/SKILL.md", "**/agents/*.md", "**/commands/*.md", "**/hooks/**", "**/.mcp.json", "**/scripts/**"],
+      "rule": "Treat skill, agent, command, hook, and MCP text as executable supply-chain behavior, not inert documentation. Review the body and code blocks for credential reads, data exfiltration, hidden network sinks, destructive defaults, permission bypass, prompt injection, untrusted pipe-to-shell, and instructions that contradict declared tool limits. A benign frontmatter score does not make malicious or unsafe body instructions acceptable."
+    },
+    {
+      "id": "declared-tools-match-observed-behavior",
+      "severity": "high",
+      "scope": ["**/SKILL.md", "**/agents/*.md", "**/commands/*.md"],
+      "rule": "Tool permissions must be least-privilege and behaviorally coherent. Every fully-qualified MCP tool invoked by an agent body must be in its `tools`; skills use `allowed-tools` plus optional `disallowed-tools`. Flag wildcard or Bash scope expansion that is unnecessary for the documented workflow, a network/filesystem action absent from the declarations, or a denylist that overlaps the allowlist. Do not demand a tool merely because it appears in a quoted counterexample or fenced output sample."
+    },
+    {
+      "id": "external-mirror-authority-is-upstream",
+      "severity": "high",
+      "scope": ["community/**"],
+      "rule": "A plugin containing `.source.json` is sync-owned. Pure mirrors are changed upstream and then re-synced; do not locally harden or repair mirrored files unless the corresponding `sources.yaml` entry is deliberately `curated: true`, which freezes further sync writes. A PR must not edit engine-owned mirror files without the source/lock/provenance changes that explain how the edit survives the next sync."
+    },
+    {
+      "id": "plugin-layout-and-launch-are-relocatable",
+      "severity": "high",
+      "scope": ["**/.claude-plugin/plugin.json", "**/.mcp.json", "**/mcp/*.json", "**/hooks/**", "**/package.json"],
+      "rule": "An installed plugin must work outside the contributor's checkout. Its manifest lives at `.claude-plugin/plugin.json`; commands, hooks, MCP server launchers, and file references use plugin-relative or package-resolved paths, never `/absolute/path`, a developer home directory, or an unexpanded placeholder. Declared components must exist in the shipped plugin and executable entrypoints must retain their shebang/mode."
+    },
+    {
+      "id": "examples-and-claims-must-be-semantically-complete",
+      "severity": "medium",
+      "scope": ["**/*.md", "**/*.ts", "**/*.js", "**/*.py"],
+      "rule": "Code examples and operational claims are part of the product because agents copy and execute them. When a PR adds a plan/tier/enum/table/flag, verify every switch, union, formula, fallback, and mirrored explanation covers the same case. Do not invent pricing, verification badges, performance claims, partner names, or success evidence; claims must be supported by a cited authoritative source or recorded proof."
+    },
+    {
+      "id": "new-plugin-submission-proof",
+      "severity": "medium",
+      "scope": ["**/.claude-plugin/plugin.json", "**/docs/**"],
+      "rule": "A new authored plugin follows the tiered submission standard and links its submission issue: micro requires PRD; standard requires PRD+ADR; a pack/featured/paid surface requires PRD+ADR+ONE-PAGER, plus CFO-ONE-PAGER when money is the pitch. External `.source.json` mirrors are exempt because their documents live upstream. Review semantic completeness and value claims; CI already checks deterministic file presence."
+    }
+  ]
+}

--- a/plugins/mcp/.greptile/config.json
+++ b/plugins/mcp/.greptile/config.json
@@ -1,0 +1,28 @@
+{
+  "rules": [
+    {
+      "id": "mcp-server-startup-is-install-independent",
+      "severity": "high",
+      "scope": ["**/.mcp.json", "**/mcp/*.json", "**/.claude-plugin/plugin.json", "**/package.json", "**/src/**", "**/dist/**"],
+      "rule": "MCP server startup must resolve from the installed plugin/package and succeed over stdio without a developer checkout. Flag absolute paths, placeholders, missing manifest discovery paths, wrong bin targets, absent shebangs, non-executable launch files, stdout logging before protocol startup, and source changes whose required committed dist/bin output is stale."
+    },
+    {
+      "id": "mcp-tool-boundaries-validate-and-fail-closed",
+      "severity": "high",
+      "scope": ["**/src/**", "**/server.*", "**/lib.*"],
+      "rule": "Every MCP tool validates untrusted arguments before filesystem, SQL, shell, or network use; returns structured errors; and fails closed on parse/provider/runtime errors. Never interpolate arguments into shell or SQL strings, silently coerce missing observations into real zero/false values, swallow authorization failures, or advertise success after a partial mutation. Preserve read-only vs mutation classification and explicit confirmation chokepoints."
+    },
+    {
+      "id": "mcp-credentials-stay-service-bound",
+      "severity": "high",
+      "scope": ["**/.mcp.json", "**/mcp/*.json", "**/src/**", "**/server.*", "**/lib.*"],
+      "rule": "MCP plugins consume named environment variables through placeholders/config and send a credential only to its intended service. Never embed real keys, enumerate/serialize the whole environment, read foreign credential stores, echo secrets into protocol errors/logs, or forward user data to an unrelated endpoint. Test fixtures use obvious non-secret values and local stub servers."
+    },
+    {
+      "id": "mcp-mutating-tools-need-auditable-chokepoints",
+      "severity": "high",
+      "scope": ["**/src/**", "**/server.*", "**/lib.*"],
+      "rule": "A tool that can write, delete, push, merge, reset, publish, send, or change external state must be distinguishable from read-only tools, validate its exact target, enforce the repo's approval/recommend-only policy, and return evidence of what changed. Adding a mutation synonym or alternate execution path must pass through the same classifier/authorization/audit chokepoint and needs adversarial regression coverage."
+    }
+  ]
+}

--- a/scripts/.greptile/config.json
+++ b/scripts/.greptile/config.json
@@ -1,0 +1,45 @@
+{
+  "rules": [
+    {
+      "id": "catalog-checks-cover-every-version-surface",
+      "severity": "high",
+      "scope": ["**"],
+      "rule": "`.claude-plugin/marketplace.extended.json` is the source for catalog/display identity. Sync, bump, and reconstruction tooling must keep plugin.json, every sibling SKILL.md version, the tracked marketplace.json, generated package metadata, and README blocks coherent. A `--check` command must inspect every surface it claims and report missing layouts instead of silently skipping them. Version reconstruction must never move a public version backward; compare all authoritative pre-existing surfaces before choosing a floor."
+    },
+    {
+      "id": "external-sync-is-least-privilege-per-source",
+      "severity": "high",
+      "scope": [
+        "sync-external.mjs",
+        "sync-lockfile.mjs",
+        "sync-lint-ignores.mjs",
+        "scan-synced-content.mjs",
+        "scan-allowlist.txt"
+      ],
+      "rule": "External sync is mirror-by-default, per-source, and fail-closed. Include patterns are root-anchored unless recursive breadth is explicit; matching must preserve anchor semantics. Drift, errors, REFUSE findings, lock updates, quarantine, and orphan pruning are attributed to the affected source rather than aborting or approving unrelated sources. `curated: true` is a hard freeze: no clone, write, or prune even under force. Only files recorded as engine-owned may be deleted."
+    },
+    {
+      "id": "scanner-grade-semantics-are-stable",
+      "severity": "high",
+      "scope": ["scan-synced-content.mjs", "scan-synced-content.test.mjs", "scan-allowlist.txt"],
+      "rule": "The security scanner's grade ladder is a contract: REFUSE is unwaivable and reserved for high-confidence theft/execution shapes; CHALLENGE requires a path/finding-scoped human rationale; FLAG is advisory. Keep foreign credential stores, wholesale environment harvest, obfuscation, and pipe-to-shell fail-closed without misclassifying a named credential sent to its own service as theft. Documentation examples are not executable code, while SKILL.md instructions are executable behavior. Any matcher/grade change needs adversarial fixtures for both the malicious and legitimate neighboring cases."
+    },
+    {
+      "id": "validator-executes-against-intended-tree",
+      "severity": "high",
+      "scope": [
+        "validate-skills-schema.py",
+        "pr-prescreen/**",
+        "kernel-shadow-validation.mjs",
+        "validate-mcp-config.mjs"
+      ],
+      "rule": "`validate-skills-schema.py` is the sole production prose validator and anchors its repository root to its own path. Callers must prove which tree is being graded; never assume cwd changes the scan root. Secondary validators delegate or remain explicitly advisory. Kernel reads are shadow observations, not authority. A validator wrapper must fail visibly on zero/invalid results and needs a regression fixture that demonstrates the intended base-vs-PR tree."
+    },
+    {
+      "id": "generators-fix-authoritative-inputs",
+      "severity": "medium",
+      "scope": ["**"],
+      "rule": "When generated catalogs, README blocks, promoted skills, stats, zips, or manifests are wrong, fix the authoritative input or generator and regenerate. Never patch a derived mirror to hide source drift. Generation must be deterministic and check mode must compare the full promised output without mutating the tree."
+    }
+  ]
+}

--- a/scripts/validate-greptile-config.mjs
+++ b/scripts/validate-greptile-config.mjs
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const CONFIG_DIR = '.greptile';
+const SKIP_DIRS = new Set(['.git', 'node_modules', 'dist', 'build', 'coverage', '.astro']);
+const FILTER_ARRAY_FIELDS = [
+  'labels',
+  'disabledLabels',
+  'includeAuthors',
+  'excludeAuthors',
+  'includeBranches',
+  'excludeBranches',
+  'commentTypes',
+  'disabledRules',
+];
+
+function readJson(file, errors) {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch (error) {
+    errors.push(`${file}: invalid JSON (${error.message})`);
+    return null;
+  }
+}
+
+function validateStringArray(value, label, errors) {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string' || !item.trim())) {
+    errors.push(`${label}: expected an array of non-empty strings`);
+  }
+}
+
+function validateScopes(scope, label, errors) {
+  validateStringArray(scope, label, errors);
+  if (Array.isArray(scope) && scope.some((pattern) => pattern.includes('../'))) {
+    errors.push(`${label}: parent-directory patterns are not allowed`);
+  }
+}
+
+function findGreptileDirs(repoRoot) {
+  const found = [];
+
+  function walk(dir) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (!entry.isDirectory() || SKIP_DIRS.has(entry.name)) continue;
+      const child = path.join(dir, entry.name);
+      if (entry.name === CONFIG_DIR) {
+        found.push(child);
+      } else {
+        walk(child);
+      }
+    }
+  }
+
+  walk(repoRoot);
+  return found.sort();
+}
+
+function validateConfig(configPath, config, globalRuleIds, errors, stats) {
+  if (!config || typeof config !== 'object' || Array.isArray(config)) {
+    errors.push(`${configPath}: top level must be an object`);
+    return;
+  }
+
+  for (const field of FILTER_ARRAY_FIELDS) {
+    if (field in config) validateStringArray(config[field], `${configPath}:${field}`, errors);
+  }
+
+  if ('strictness' in config && ![1, 2, 3].includes(config.strictness)) {
+    errors.push(`${configPath}:strictness must be 1, 2, or 3`);
+  }
+
+  if ('ignorePatterns' in config && typeof config.ignorePatterns !== 'string') {
+    errors.push(`${configPath}:ignorePatterns must be a newline-separated string`);
+  }
+
+  if (config.context?.repos !== undefined) {
+    validateStringArray(config.context.repos, `${configPath}:context.repos`, errors);
+    const repos = config.context.repos;
+    if (Array.isArray(repos)) {
+      if (new Set(repos).size !== repos.length) {
+        errors.push(`${configPath}:context.repos contains duplicates`);
+      }
+      for (const repo of repos) {
+        if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo)) {
+          errors.push(
+            `${configPath}:context.repos has invalid owner/repo value ${JSON.stringify(repo)}`,
+          );
+        }
+      }
+    }
+  }
+
+  if (config.rules === undefined) return;
+  if (!Array.isArray(config.rules)) {
+    errors.push(`${configPath}:rules must be an array`);
+    return;
+  }
+
+  for (const [index, rule] of config.rules.entries()) {
+    const label = `${configPath}:rules[${index}]`;
+    if (!rule || typeof rule !== 'object' || Array.isArray(rule)) {
+      errors.push(`${label}: expected an object`);
+      continue;
+    }
+    if (typeof rule.id !== 'string' || !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(rule.id)) {
+      errors.push(`${label}: id must be stable lowercase kebab-case`);
+    } else if (globalRuleIds.has(rule.id)) {
+      errors.push(`${label}: duplicate rule id ${rule.id}`);
+    } else {
+      globalRuleIds.add(rule.id);
+    }
+    if (typeof rule.rule !== 'string' || rule.rule.trim().length < 20) {
+      errors.push(`${label}: rule must be a specific non-empty instruction`);
+    }
+    if (rule.severity !== undefined && !['low', 'medium', 'high'].includes(rule.severity)) {
+      errors.push(`${label}: severity must be low, medium, or high`);
+    }
+    if (rule.scope !== undefined) validateScopes(rule.scope, `${label}:scope`, errors);
+    if (rule.enabled !== undefined && typeof rule.enabled !== 'boolean') {
+      errors.push(`${label}: enabled must be boolean`);
+    }
+    stats.rules += 1;
+  }
+}
+
+function validateFiles(filesPath, data, errors, stats) {
+  if (!data || typeof data !== 'object' || !Array.isArray(data.files)) {
+    errors.push(`${filesPath}: expected an object with a files array`);
+    return;
+  }
+  const scopeRoot = path.dirname(path.dirname(filesPath));
+  for (const [index, item] of data.files.entries()) {
+    const label = `${filesPath}:files[${index}]`;
+    if (!item || typeof item !== 'object' || Array.isArray(item)) {
+      errors.push(`${label}: expected an object`);
+      continue;
+    }
+    if (typeof item.path !== 'string' || !item.path.trim() || item.path.includes('../')) {
+      errors.push(`${label}: path must be a non-empty local path without ../`);
+    } else if (!fs.existsSync(path.resolve(scopeRoot, item.path))) {
+      errors.push(`${label}: referenced file does not exist: ${item.path}`);
+    }
+    if (item.description !== undefined && typeof item.description !== 'string') {
+      errors.push(`${label}: description must be a string`);
+    }
+    if (item.scope !== undefined) validateScopes(item.scope, `${label}:scope`, errors);
+    stats.files += 1;
+  }
+}
+
+export function validateRepository(repoRoot) {
+  const root = path.resolve(repoRoot);
+  const errors = [];
+  const stats = { configDirs: 0, rules: 0, files: 0 };
+  const globalRuleIds = new Set();
+  const rootConfig = path.join(root, CONFIG_DIR, 'config.json');
+
+  if (!fs.existsSync(rootConfig)) {
+    errors.push(`${rootConfig}: root Greptile config is required`);
+  }
+
+  for (const greptileDir of findGreptileDirs(root)) {
+    stats.configDirs += 1;
+    const configPath = path.join(greptileDir, 'config.json');
+    const filesPath = path.join(greptileDir, 'files.json');
+    const rulesPath = path.join(greptileDir, 'rules.md');
+
+    if (fs.existsSync(configPath)) {
+      validateConfig(configPath, readJson(configPath, errors), globalRuleIds, errors, stats);
+    }
+    if (fs.existsSync(filesPath)) {
+      validateFiles(filesPath, readJson(filesPath, errors), errors, stats);
+    }
+    if (fs.existsSync(rulesPath) && !fs.readFileSync(rulesPath, 'utf8').trim()) {
+      errors.push(`${rulesPath}: rules.md must not be empty`);
+    }
+  }
+
+  return { errors, stats };
+}
+
+function main() {
+  const repoRoot = process.argv[2]
+    ? path.resolve(process.argv[2])
+    : path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+  const { errors, stats } = validateRepository(repoRoot);
+  if (errors.length) {
+    for (const error of errors) console.error(`greptile-config: ${error}`);
+    console.error(
+      `greptile-config: FAIL (${errors.length} error${errors.length === 1 ? '' : 's'})`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+  console.log(
+    `greptile-config: OK (${stats.configDirs} config dirs, ${stats.rules} rules, ${stats.files} context files)`,
+  );
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/validate-greptile-config.test.mjs
+++ b/scripts/validate-greptile-config.test.mjs
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+
+import { validateRepository } from './validate-greptile-config.mjs';
+
+function fixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'greptile-config-test-'));
+  fs.mkdirSync(path.join(root, '.greptile'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'ARCHITECTURE.md'), '# Architecture\n');
+  fs.writeFileSync(
+    path.join(root, '.greptile', 'config.json'),
+    JSON.stringify({
+      strictness: 2,
+      context: { repos: ['acme/contracts'] },
+      rules: [
+        {
+          id: 'root-rule',
+          rule: 'Reject changes that violate the architecture contract.',
+          severity: 'high',
+        },
+      ],
+    }),
+  );
+  fs.writeFileSync(
+    path.join(root, '.greptile', 'files.json'),
+    JSON.stringify({ files: [{ path: 'ARCHITECTURE.md', scope: ['src/**'] }] }),
+  );
+  return root;
+}
+
+test('accepts valid root and nested cascading configuration', () => {
+  const root = fixture();
+  fs.mkdirSync(path.join(root, 'src', '.greptile'), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, 'src', '.greptile', 'config.json'),
+    JSON.stringify({
+      rules: [{ id: 'source-rule', rule: 'Every source mutation must validate its exact target.' }],
+    }),
+  );
+  const result = validateRepository(root);
+  assert.deepEqual(result.errors, []);
+  assert.deepEqual(result.stats, { configDirs: 2, rules: 2, files: 1 });
+});
+
+test('rejects duplicate rule ids across cascading configs', () => {
+  const root = fixture();
+  fs.mkdirSync(path.join(root, 'src', '.greptile'), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, 'src', '.greptile', 'config.json'),
+    JSON.stringify({
+      rules: [{ id: 'root-rule', rule: 'This duplicate must be rejected across the repository.' }],
+    }),
+  );
+  const { errors } = validateRepository(root);
+  assert.ok(errors.some((error) => error.includes('duplicate rule id root-rule')));
+});
+
+test('rejects invalid severity and parent-relative scopes', () => {
+  const root = fixture();
+  const configPath = path.join(root, '.greptile', 'config.json');
+  const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+  config.rules[0].severity = 'critical';
+  config.rules[0].scope = ['../secrets/**'];
+  fs.writeFileSync(configPath, JSON.stringify(config));
+  const { errors } = validateRepository(root);
+  assert.ok(errors.some((error) => error.includes('severity must be low, medium, or high')));
+  assert.ok(errors.some((error) => error.includes('parent-directory patterns are not allowed')));
+});
+
+test('rejects missing context files and malformed repository names', () => {
+  const root = fixture();
+  const configPath = path.join(root, '.greptile', 'config.json');
+  const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+  config.context.repos = ['missing-owner-separator'];
+  fs.writeFileSync(configPath, JSON.stringify(config));
+  fs.writeFileSync(
+    path.join(root, '.greptile', 'files.json'),
+    JSON.stringify({ files: [{ path: 'MISSING.md' }] }),
+  );
+  const { errors } = validateRepository(root);
+  assert.ok(errors.some((error) => error.includes('invalid owner/repo value')));
+  assert.ok(errors.some((error) => error.includes('referenced file does not exist')));
+});


### PR DESCRIPTION
Rescues work that was sitting uncommitted in a `/tmp` worktree, rebased onto current `main` and reconciled with #1124.

## What

- **`scripts/validate-greptile-config.mjs`** (new, 205 lines) — deterministic validator for the cascading `.greptile/` policy tree: the root policy plus seven directory-scoped configs (`.github/workflows/`, `freshie/`, `marketplace/`, `packages/`, `plugins/`, `plugins/mcp/`, `scripts/`). Emits config-dir / rule / context-file counts so drift is visible instead of silent.
- **`scripts/validate-greptile-config.test.mjs`** (new, 86 lines) — 4 `node:test` cases.
- **Seven scoped `.greptile/config.json` files** — per-area review policy version-controlled next to the code it governs, rather than one root blob.
- **`.greptile/{config.json,files.json,rules.md}`** — root policy updated.
- **`package.json`** — `validate:greptile` script.
- **`.github/workflows/validate-plugins.yml`** — runs the unit test then the validator inside the existing `validate` job.
- **`CLAUDE.md`** — corrects the "both AI reviewers are dark" claim: Greptile is active through the GitHub App and has reviewed recent PRs. Findings stay **advisory**; the merge gate is unchanged.

## Why + decision rationale

The `.greptile/` tree had grown to eight config files with no check that they parse, resolve, or stay mutually consistent. A silently-broken policy file degrades review coverage with zero signal.

**Chose a standalone validator invoked from the existing `validate` job over a new dedicated workflow**, because a separate workflow would need its own always-reports guarantee before it could safely become a required context; folding it into a job already in `ci-required`'s `needs:` inherits that property for free and avoids the path-filtered-required-check trap documented in CLAUDE.md.

## Layer touched + invariant change

CI gate layer. **This check is BLOCKING** — the `validate` job is in `ci-required`'s `needs:`. That is deliberate: the validator is deterministic, fast, and currently passes clean. No skill/agent/marketplace schema or runtime surface is touched.

## Conflict reconciliation with #1124

This branch was authored before #1124 (`fix(greptile): filter redundant automated reviews`) merged, so `.greptile/config.json` conflicted. Both sides were additive and were merged as a union rather than one overwriting the other:

| Field | Resolution |
|---|---|
| `triggerOnDrafts`, `disabledLabels`, `excludeAuthors`, `ignoreKeywords`, `triggerOnUpdates: false` | **kept from #1124** — its deliberate noise cut |
| `statusCheck`, `updateExistingSummaryComment`, `context.repos`, `instructions` | **kept from this branch** |
| `strictness` | **kept `3` from `main`** — this branch had lowered it to `2`; that was incidental, and weakening review strictness is not the purpose of this PR |
| `ignorePatterns` | **union** — `main`'s `marketplace/src/data/npm-stats.json` plus this branch's `skills/.curated/`, `yarn.lock`, `bun.lock*`, `**/*.map`, `**/*.snap`; the bare `*.min.js` was dropped in favour of the recursive `**/*.min.js` that supersedes it |
| `kernel-pin-frozen-during-soak` rule | **dropped as superseded.** This branch renames it to `kernel-authority-frozen-during-soak` with corrected text. Keeping both would have shipped a direct contradiction — the old rule says "do not suggest bumping the pin", the new one says a routine exact-version bump is allowed and is separate from authority (which matches current CLAUDE.md doctrine). |

Final: 11 rules, no duplicate ids.

## Verification

```
$ node --test scripts/validate-greptile-config.test.mjs
# tests 4 / # pass 4 / # fail 0

$ node scripts/validate-greptile-config.mjs
greptile-config: OK (8 config dirs, 40 rules, 17 context files)
exit=0
```

Both re-run **after** the conflict resolution and **after** lint-staged reformatting. Rebased clean onto `891c164a9`; 1 ahead, 0 behind.

## Risk

Low-moderate. The only behavioral change outside the `.greptile/` policy data is the new blocking CI step, which passes on the current tree. Rollback is `git revert` of the single commit — it restores `.greptile/config.json` to the post-#1124 state and removes the CI step.

## Operational impact

None. No env vars, migrations, dependencies, secrets, cost, or deploy-order change. The validator uses only Node builtins.

## Follow-up / deferred

Regenerated marketplace build artifacts (`marketplace/{src,public}/data/*.json`, ~36k lines of churn) were **deliberately excluded** — they are pipeline output, not source, and CLAUDE.md says not to commit them. `npm run build` regenerates them.

## Provenance

This work existed only as uncommitted changes in a `/tmp` worktree (`/tmp/greptile-filters-QwvGAN`). `/tmp` on this host is `D /tmp 1777 root root 30d` — emptied on boot with a 30-day age sweep — so it was one reboot away from being lost. Committing it was the point.