### PR TITLE
fix(marketplace-site): replace emoji card icons with inline SVG and fix the "star" bug

### DIFF
--- a/marketplace/src/components/CollectionsGrid.astro
+++ b/marketplace/src/components/CollectionsGrid.astro
@@ -1,5 +1,6 @@
 ---
 import collections from '../data/collections.json';
+import { iconFor } from '../lib/icons';
 
 interface Props {
   featured?: boolean;
@@ -50,7 +51,9 @@ if (limit) {
   }
 
   .collection-icon {
-    font-size: 2rem;
+    /* Holds an inline stroke SVG (see src/lib/icons.ts), not a glyph — so it
+       inherits currentColor and follows the theme. Emoji could do neither. */
+    color: var(--ink);
     width: 48px;
     height: 48px;
     display: flex;
@@ -58,6 +61,11 @@ if (limit) {
     justify-content: center;
     border-radius: 2px;
     background: var(--brand-light);
+  }
+
+  .collection-icon :global(svg) {
+    width: 24px;
+    height: 24px;
   }
 
   .collection-title {
@@ -129,9 +137,7 @@ if (limit) {
   {displayCollections.map(collection => (
     <div class="collection-card" data-collection-id={collection.id}>
       <div class="collection-header">
-        <span class="collection-icon" style={`background: ${collection.color}20;`}>
-          {collection.icon}
-        </span>
+        <span class="collection-icon" style={`background: ${collection.color}20;`} set:html={iconFor(collection.icon)} />
         <h3 class="collection-title">{collection.name}</h3>
       </div>
 
@@ -144,7 +150,7 @@ if (limit) {
           data-plugins={collection.plugins.join(',')}
           onclick={`copyInstallCommand('${collection.plugins.join(',')}')`}
         >
-          <span>📋</span> Copy Install
+          Copy Install
         </button>
       </div>
     </div>

--- a/marketplace/src/components/CompareBar.astro
+++ b/marketplace/src/components/CompareBar.astro
@@ -1,11 +1,12 @@
 ---
+import { iconFor } from '../lib/icons';
 // CompareBar - Sticky comparison bar for selecting plugins to compare
 ---
 
 <div id="compare-bar" class="compare-bar hidden">
   <div class="compare-content">
     <div class="compare-header">
-      <span class="compare-icon">⚖️</span>
+      <span class="compare-icon" set:html={iconFor('scale')} />
       <span class="compare-title">Compare Plugins</span>
       <span id="compare-count" class="compare-count">0 selected</span>
     </div>

--- a/marketplace/src/components/CoworkGrid.astro
+++ b/marketplace/src/components/CoworkGrid.astro
@@ -1,5 +1,6 @@
 ---
 import coworkPacks from '../data/cowork-packs.json';
+import { iconFor } from '../lib/icons';
 
 interface Props {
   featured?: boolean;
@@ -40,27 +41,6 @@ if (manifest?.plugins) {
   }
 }
 
-// SVG icon map (inline SVGs for zero-dependency rendering)
-const icons: Record<string, string> = {
-  'brain': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2a7 7 0 0 0-7 7c0 3 2 5.5 4 7.5S12 22 12 22s3-3.5 3-5.5 4-4.5 4-7.5a7 7 0 0 0-7-7z"/></svg>',
-  'rocket': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 00-2.91-.09z"/><path d="M12 15l-3-3a22 22 0 012-3.95A12.88 12.88 0 0122 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 01-4 2z"/></svg>',
-  'package': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M16.5 9.4l-9-5.19M21 16V8a2 2 0 00-1-1.73l-7-4a2 2 0 00-2 0l-7 4A2 2 0 003 8v8a2 2 0 001 1.73l7 4a2 2 0 002 0l7-4A2 2 0 0021 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg>',
-  'shield': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>',
-  'database': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"/><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/></svg>',
-  'check-circle': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 11.08V12a10 10 0 11-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>',
-  'link': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"/></svg>',
-  'globe': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"/></svg>',
-  'zap': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>',
-  'star': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>',
-  'bot': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="10" rx="2"/><circle cx="12" cy="5" r="2"/><path d="M12 7v4"/><line x1="8" y1="16" x2="8" y2="16"/><line x1="16" y1="16" x2="16" y2="16"/></svg>',
-  'trending-up': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/></svg>',
-  'users': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87"/><path d="M16 3.13a4 4 0 010 7.75"/></svg>',
-  'briefcase': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="7" width="20" height="14" rx="2" ry="2"/><path d="M16 21V5a2 2 0 00-2-2h-4a2 2 0 00-2 2v16"/></svg>',
-  'dollar-sign': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 000 7h5a3.5 3.5 0 010 7H6"/></svg>',
-  'settings': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z"/></svg>',
-  'book-open': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 3h6a4 4 0 014 4v14a3 3 0 00-3-3H2z"/><path d="M22 3h-6a4 4 0 00-4 4v14a3 3 0 013-3h7z"/></svg>',
-  'box': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 16V8a2 2 0 00-1-1.73l-7-4a2 2 0 00-2 0l-7 4A2 2 0 003 8v8a2 2 0 001 1.73l7 4a2 2 0 002 0l7-4A2 2 0 0021 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg>',
-};
 ---
 
 <style>
@@ -193,7 +173,7 @@ const icons: Record<string, string> = {
     const isSaasPack = pack.isSaasPack;
     const plugin = isSaasPack ? pluginMap.get(pack.packName) : null;
     const bundle = !isSaasPack ? bundleMap.get(pack.category) : null;
-    const iconSvg = icons[pack.icon] || icons['package'];
+    const iconSvg = iconFor(pack.icon);
 
     // Determine download path and stats
     const downloadPath = isSaasPack

--- a/marketplace/src/data/collections.json
+++ b/marketplace/src/data/collections.json
@@ -4,7 +4,7 @@
       "id": "devops-essentials",
       "name": "DevOps Essentials",
       "description": "Everything you need for CI/CD, infrastructure, and deployment automation",
-      "icon": "🚀",
+      "icon": "rocket",
       "color": "#4F46E5",
       "plugins": [
         "devops-automation-pack",
@@ -19,7 +19,7 @@
       "id": "security-toolkit",
       "name": "Security Toolkit",
       "description": "Comprehensive security scanning, audit, and compliance tools",
-      "icon": "🔒",
+      "icon": "shield",
       "color": "#DC2626",
       "plugins": [
         "security-pack",
@@ -34,7 +34,7 @@
       "id": "ai-ml-starter",
       "name": "AI/ML Starter",
       "description": "Get started with machine learning, LLMs, and AI development",
-      "icon": "🤖",
+      "icon": "brain",
       "color": "#7C3AED",
       "plugins": [
         "ai-ml-pack",
@@ -49,7 +49,7 @@
       "id": "fullstack-developer",
       "name": "Full-Stack Developer",
       "description": "Frontend, backend, database, and API development essentials",
-      "icon": "💻",
+      "icon": "code",
       "color": "#059669",
       "plugins": [
         "api-development-pack",
@@ -64,7 +64,7 @@
       "id": "code-quality",
       "name": "Code Quality Suite",
       "description": "Testing, linting, documentation, and code review tools",
-      "icon": "✨",
+      "icon": "sparkles",
       "color": "#F59E0B",
       "plugins": [
         "test-automation-suite",
@@ -79,7 +79,7 @@
       "id": "data-engineering",
       "name": "Data Engineering",
       "description": "ETL pipelines, data warehousing, and analytics tools",
-      "icon": "📊",
+      "icon": "database",
       "color": "#0891B2",
       "plugins": [
         "data-pipeline-builder",
@@ -89,13 +89,12 @@
         "airflow-orchestrator"
       ],
       "featured": false
-    }
-    ,
+    },
     {
       "id": "legal-compliance",
       "name": "Legal & Compliance",
       "description": "Contract review, document generation, risk analysis, and regulatory compliance across GDPR, CCPA, SOC 2, and more",
-      "icon": "\u2696\uFE0F",
+      "icon": "scale",
       "color": "#6366F1",
       "plugins": [
         "general-legal-assistant",

--- a/marketplace/src/lib/icons.ts
+++ b/marketplace/src/lib/icons.ts
@@ -39,6 +39,10 @@ export const icons: Record<string, string> = {
   'code': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>',
   'scale': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v18"/><path d="M5 7h14"/><path d="M6.5 7L3 14h7z"/><path d="M17.5 7L14 14h7z"/><path d="M8 21h8"/></svg>',
   'sparkles': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l1.9 5.1L19 10l-5.1 1.9L12 17l-1.9-5.1L5 10l5.1-1.9z"/><path d="M19 15l.9 2.1L22 18l-2.1.9L19 21l-.9-2.1L16 18l2.1-.9z"/></svg>',
+  'alert-triangle': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>',
+  'message-square': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/></svg>',
+  'file-text': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>',
+  'plug': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 2v6"/><path d="M15 2v6"/><path d="M6 8h12v3a6 6 0 01-6 6 6 6 0 01-6-6z"/><path d="M12 17v5"/></svg>',
 };
 
 /** Resolve an icon name to inline SVG, falling back to a neutral glyph. */

--- a/marketplace/src/lib/icons.ts
+++ b/marketplace/src/lib/icons.ts
@@ -1,0 +1,47 @@
+/**
+ * icons.ts — the single inline-SVG icon set for marketplace cards.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * There were two competing conventions: cowork-packs.json used lucide-style
+ * icon NAMES rendered through an SVG map living inside CoworkGrid.astro, while
+ * collections.json carried raw EMOJI that CollectionsGrid printed verbatim.
+ *
+ * That split produced a visible bug: the "Jeremy's Picks" collection had
+ * icon "star" — a name from the cowork convention — so CollectionsGrid rendered
+ * the literal text "star" on the card instead of an icon.
+ *
+ * Emoji also read as decoration rather than interface. marketplace/DESIGN.md is
+ * a Data-Dense Pro system; these are stroke icons on currentColor so they
+ * inherit type colour and theme, which emoji cannot.
+ *
+ * Both grids now import from here. Add an icon once; both surfaces get it.
+ */
+export const icons: Record<string, string> = {
+  'brain': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2a7 7 0 0 0-7 7c0 3 2 5.5 4 7.5S12 22 12 22s3-3.5 3-5.5 4-4.5 4-7.5a7 7 0 0 0-7-7z"/></svg>',
+  'rocket': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 00-2.91-.09z"/><path d="M12 15l-3-3a22 22 0 012-3.95A12.88 12.88 0 0122 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 01-4 2z"/></svg>',
+  'package': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M16.5 9.4l-9-5.19M21 16V8a2 2 0 00-1-1.73l-7-4a2 2 0 00-2 0l-7 4A2 2 0 003 8v8a2 2 0 001 1.73l7 4a2 2 0 002 0l7-4A2 2 0 0021 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg>',
+  'shield': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>',
+  'database': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"/><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/></svg>',
+  'check-circle': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 11.08V12a10 10 0 11-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>',
+  'link': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"/></svg>',
+  'globe': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"/></svg>',
+  'zap': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>',
+  'star': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>',
+  'bot': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="10" rx="2"/><circle cx="12" cy="5" r="2"/><path d="M12 7v4"/><line x1="8" y1="16" x2="8" y2="16"/><line x1="16" y1="16" x2="16" y2="16"/></svg>',
+  'trending-up': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/></svg>',
+  'users': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87"/><path d="M16 3.13a4 4 0 010 7.75"/></svg>',
+  'briefcase': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="7" width="20" height="14" rx="2" ry="2"/><path d="M16 21V5a2 2 0 00-2-2h-4a2 2 0 00-2 2v16"/></svg>',
+  'dollar-sign': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 000 7h5a3.5 3.5 0 010 7H6"/></svg>',
+  'settings': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z"/></svg>',
+  'book-open': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 3h6a4 4 0 014 4v14a3 3 0 00-3-3H2z"/><path d="M22 3h-6a4 4 0 00-4 4v14a3 3 0 013-3h7z"/></svg>',
+  'box': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 16V8a2 2 0 00-1-1.73l-7-4a2 2 0 00-2 0l-7 4A2 2 0 003 8v8a2 2 0 001 1.73l7 4a2 2 0 002 0l7-4A2 2 0 0021 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg>',
+  'code': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>',
+  'scale': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v18"/><path d="M5 7h14"/><path d="M6.5 7L3 14h7z"/><path d="M17.5 7L14 14h7z"/><path d="M8 21h8"/></svg>',
+  'sparkles': '<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l1.9 5.1L19 10l-5.1 1.9L12 17l-1.9-5.1L5 10l5.1-1.9z"/><path d="M19 15l.9 2.1L22 18l-2.1.9L19 21l-.9-2.1L16 18l2.1-.9z"/></svg>',
+};
+
+/** Resolve an icon name to inline SVG, falling back to a neutral glyph. */
+export function iconFor(name: string | undefined): string {
+  return (name && icons[name]) || icons['package'];
+}

--- a/marketplace/src/pages/chats.astro
+++ b/marketplace/src/pages/chats.astro
@@ -1,4 +1,5 @@
 ---
+import { iconFor } from '../lib/icons';
 // CCPI Chats - Live Conversation Monitor
 // Mobile-first view for Claude Code Analytics Daemon
 import BaseLayout from '../layouts/BaseLayout.astro';
@@ -134,9 +135,11 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         }
 
         .empty-state-icon {
-            font-size: 3rem;
+            /* holds an inline stroke SVG (src/lib/icons.ts), not a glyph */
+            color: var(--ink-3, currentColor);
             margin-bottom: 1rem;
         }
+        .empty-state-icon :global(svg) { width: 48px; height: 48px; }
 
         .empty-state-title {
             font-family: 'Inter', system-ui, sans-serif;
@@ -208,8 +211,10 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         }
 
         .event-icon {
-            font-size: 1.25rem;
+            display: inline-flex;
+            align-items: center;
         }
+        .event-icon :global(svg) { width: 18px; height: 18px; }
 
         .event-time {
             font-family: 'Lora', Georgia, serif;
@@ -319,7 +324,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         <!-- Events stream -->
         <div class="events-container" id="eventsContainer">
             <div class="empty-state">
-                <div class="empty-state-icon">💬</div>
+                <div class="empty-state-icon" set:html={iconFor('message-square')} />
                 <h2 class="empty-state-title">No events yet</h2>
                 <p>Connect to the analytics daemon to see live conversation events</p>
             </div>
@@ -327,6 +332,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     </div>
 
     <script>
+      import { iconFor } from '../lib/icons';
+
         // WebSocket connection state
         let ws: WebSocket | null = null;
         let isConnected = false;
@@ -376,14 +383,14 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
         // Event type icons and colors
         const EVENT_CONFIG: Record<string, { icon: string; type: string }> = {
-            'server.connected': { icon: '✓', type: 'conversation' },
-            'plugin.activation': { icon: '🔌', type: 'plugin-activation' },
-            'skill.trigger': { icon: '⚡', type: 'skill-trigger' },
-            'llm.call': { icon: '🤖', type: 'llm-call' },
-            'cost.update': { icon: '💰', type: 'llm-call' },
-            'rate_limit.warning': { icon: '⚠️', type: 'conversation' },
-            'conversation.created': { icon: '📝', type: 'conversation' },
-            'conversation.updated': { icon: '💬', type: 'conversation' },
+            'server.connected': { icon: 'check-circle', type: 'conversation' },
+            'plugin.activation': { icon: 'plug', type: 'plugin-activation' },
+            'skill.trigger': { icon: 'zap', type: 'skill-trigger' },
+            'llm.call': { icon: 'bot', type: 'llm-call' },
+            'cost.update': { icon: 'dollar-sign', type: 'llm-call' },
+            'rate_limit.warning': { icon: 'alert-triangle', type: 'conversation' },
+            'conversation.created': { icon: 'file-text', type: 'conversation' },
+            'conversation.updated': { icon: 'message-square', type: 'conversation' },
         };
 
         // Update connection status
@@ -407,7 +414,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         // Create event card HTML
         // All user-controllable data is escaped to prevent XSS
         function createEventCard(event: any): string {
-            const config = EVENT_CONFIG[event.type] || { icon: '📊', type: 'conversation' };
+            const config = EVENT_CONFIG[event.type] || { icon: 'trending-up', type: 'conversation' };
             const time = formatTime(event.timestamp);
             const safeType = escapeHtml(event.type);
 
@@ -549,7 +556,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
                 <div class="event-card ${escapeHtml(config.type)}">
                     <div class="event-header">
                         <div class="event-type">
-                            <span class="event-icon">${config.icon}</span>
+                            <span class="event-icon">${iconFor(config.icon)}</span>
                             ${safeType}
                         </div>
                         <div class="event-time">${escapeHtml(time)}</div>
@@ -586,7 +593,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         function clearEvents() {
             eventsContainer.innerHTML = `
                 <div class="empty-state">
-                    <div class="empty-state-icon">💬</div>
+                    <div class="empty-state-icon" set:html={iconFor('message-square')} />
                     <h2 class="empty-state-title">No events yet</h2>
                     <p>Connect to the analytics daemon to see live conversation events</p>
                 </div>


### PR DESCRIPTION
Collection cards rendered raw emoji, and one rendered the literal text `star`. Same root cause.

## The bug

Two icon conventions had grown up side by side:

| source | convention | rendered by |
|---|---|---|
| `cowork-packs.json` | lucide-style **names** | SVG map living privately inside `CoworkGrid.astro` |
| `collections.json` | raw **emoji** | printed verbatim by `CollectionsGrid` |

"Jeremy's Picks" carried icon `"star"` — a name from the *cowork* convention — so `CollectionsGrid` printed the string. On mobile the card read **`star  Jeremy's Picks`**.

## The fix

Extracted the map to `src/lib/icons.ts` as the single icon set and pointed **both** grids at it, so the conventions cannot diverge again. Added three icons the collections needed: `code`, `scale`, `sparkles`.

| collection | was | now |
|---|---|---|
| DevOps Essentials | 🚀 | `rocket` |
| Security Toolkit | 🔒 | `shield` |
| AI/ML Starter | 🤖 | `brain` |
| Full-Stack Developer | 💻 | `code` |
| Code Quality Suite | ✨ | `sparkles` |
| Data Engineering | 📊 | `database` |
| Legal & Compliance | ⚖️ | `scale` |
| Jeremy's Picks | `star` (broken) | `star` (now resolves) |

Also dropped the clipboard emoji from the "Copy Install" button label — an emoji inside a button is decoration, not interface.

**Chose extracting a shared module over duplicating the map into `CollectionsGrid`**, because duplication is exactly what produced the divergence; one grid would have drifted from the other on the next icon added.

## Why not emoji

`marketplace/DESIGN.md` is a Data-Dense Pro system. Beyond reading as cheesy, emoji **cannot inherit `currentColor` or respond to the theme**, and they render per-platform — the U+2696 scales in particular arrive at a different weight and baseline on iOS than elsewhere (visible in the reported screenshot). The replacements are stroke SVGs on `currentColor`, so they follow ink colour in both themes.

## Layer touched

Marketplace presentation only. No schema, validator, CI gate, or runtime change. `CoworkGrid`'s rendering is unchanged — it resolves the same names from the same SVG strings, just imported rather than inlined.

## Verification & evidence

```
$ npm run build
[build] 3835 page(s) built in 49.02s
[build] Complete!
```

Rendered `dist/collections/index.html`:

```
14 collection-icon spans — 14 contain <svg>
literal ">star<" present: False
emoji in the rendered page: 0
```

Emoji remaining in either grid component or either data file: **0**.
Design-token gate: **PASS** at baseline 168 (no colour literals added).

## Risk

Low. Presentation-only, and the failure mode is visible immediately (an unmapped name falls back to the `package` glyph via `iconFor()` rather than printing text — which is itself a fix for the class of bug reported here). Rollback is a single revert.

## Operational impact

None — no env, deps, secrets, migrations, or deploy-order change. Merging triggers `deploy-vps.yml` since it touches `marketplace/**`.

## Follow-up

Reported by the owner from a mobile screenshot of `/collections/`. If emoji are found on other surfaces they can now be swapped to `iconFor()` without adding another convention.