### PR TITLE
fix(marketplace-site): point syndicated blog posts at their canonical home on startaitools

### DIFF
--- a/marketplace/src/content.config.ts
+++ b/marketplace/src/content.config.ts
@@ -78,6 +78,11 @@ const blogPostsCollection = defineCollection({
     date: z.string(),
     tags: z.array(z.string()).optional().default([]),
     featured: z.boolean().optional().default(false),
+    // Absolute canonical URL of the ORIGINAL article. These posts are syndicated
+    // copies of startaitools.com pages; without this the dual-published copy
+    // self-canonicalises and the two properties compete for the same keywords.
+    // Absent = the post is native here and self-canonicalises correctly.
+    canonical: z.string().url().optional(),
   }),
 });
 

--- a/marketplace/src/content/blog-posts/58-e2e-tests-slack-channel-launch-one-day.md
+++ b/marketplace/src/content/blog-posts/58-e2e-tests-slack-channel-launch-one-day.md
@@ -4,6 +4,7 @@ description: "How REST API auth plus IndexedDB injection unlocked 58 production 
 date: "2026-03-20"
 tags: ["testing", "ci-cd", "typescript", "automation", "claude-code", "full-stack"]
 featured: false
+canonical: "https://startaitools.com/posts/58-e2e-tests-slack-channel-launch-one-day/"
 ---
 You cannot run production E2E tests if you cannot log in. That sentence sounds obvious. It took sixteen commits to solve.
 

--- a/marketplace/src/content/blog-posts/a-green-recovery-drill-can-still-be-lying.md
+++ b/marketplace/src/content/blog-posts/a-green-recovery-drill-can-still-be-lying.md
@@ -4,6 +4,7 @@ description: "A recovery drill that passes green can still be lying. Learn four 
 date: "2026-07-18"
 tags: ["observability", "clickhouse", "disaster-recovery", "backup", "signoz", "testing", "opentelemetry", "restore-verification"]
 featured: false
+canonical: "https://startaitools.com/posts/a-green-recovery-drill-can-still-be-lying/"
 ---
 We had a backup mechanism for a SigNoz staging stack. What we did not have was a *proven* restore. Those are different claims, and the gap between them is where outages become permanent.
 

--- a/marketplace/src/content/blog-posts/adversarial-review-before-team-rollout.md
+++ b/marketplace/src/content/blog-posts/adversarial-review-before-team-rollout.md
@@ -4,6 +4,7 @@ description: "A six-lens adversarial review checked a team knowledge system agai
 date: "2026-07-09"
 tags: ["ai-agents", "security", "architecture", "authentication", "claude-code"]
 featured: false
+canonical: "https://startaitools.com/posts/adversarial-review-before-team-rollout/"
 ---
 "We shipped the safety work" is a feeling, not a fact. Before you hand a shared, governed system to a team, the only thing that converts that feeling into the truth is a structured adversarial review that verifies claims against live state — not against the design doc, and not against the diff.
 

--- a/marketplace/src/content/blog-posts/agents-md-cross-tool-plugin-brief.md
+++ b/marketplace/src/content/blog-posts/agents-md-cross-tool-plugin-brief.md
@@ -4,6 +4,7 @@ description: "A 5-device parity sweep against kobiton/automate showed iOS screen
 date: "2026-05-11"
 tags: ["claude-code", "mcp", "agents-md", "plugins", "mobile-testing", "kobiton", "parity", "devops", "appium"]
 featured: false
+canonical: "https://startaitools.com/posts/agents-md-cross-tool-plugin-brief/"
 ---
 # AGENTS.md as a Cross-Tool Plugin Brief: A Case Study from kobiton/automate
 

--- a/marketplace/src/content/blog-posts/ai-assisted-technical-writing-automation-workflows.md
+++ b/marketplace/src/content/blog-posts/ai-assisted-technical-writing-automation-workflows.md
@@ -4,6 +4,7 @@ description: "How to leverage AI agents for professional technical writing, auto
 date: "2025-09-30"
 tags: ["ai-development", "technical-writing", "blog-automation", "hugo", "netlify", "content-creation", "portfolio-development"]
 featured: false
+canonical: "https://startaitools.com/posts/ai-assisted-technical-writing-from-case-study-to-published-portfolio-in-30-minutes/"
 ---
 *2025-09-30 16:00:00*
 

--- a/marketplace/src/content/blog-posts/ai-dev-transformation-part-1-the-mess.md
+++ b/marketplace/src/content/blog-posts/ai-dev-transformation-part-1-the-mess.md
@@ -4,6 +4,7 @@ description: "How I turned a haunted repo full of Docker configs, broken YAML, a
 date: "2025-09-17"
 tags: ["ai-development", "documentation", "developer-tools", "claude", "cursor", "automation"]
 featured: false
+canonical: "https://startaitools.com/posts/from-chaos-to-one-paste-magic-part-1-the-mess-and-why-it-mattered/"
 ---
 If you've ever inherited a repo that felt like a haunted house — you open a folder and something jumps out at you (Docker configs, half-broken YAML, strange `bmad-output-00.md` files) — then you'll know how I felt walking into my own AI-Dev workspace.
 

--- a/marketplace/src/content/blog-posts/ai-dev-transformation-part-2-enterprise-library.md
+++ b/marketplace/src/content/blog-posts/ai-dev-transformation-part-2-enterprise-library.md
@@ -4,6 +4,7 @@ description: "How I took @ryancarson's excellent template foundation and evolved
 date: "2025-09-17"
 tags: ["ai-development", "documentation", "developer-tools", "claude", "cursor", "templates", "enterprise"]
 featured: false
+canonical: "https://startaitools.com/posts/from-chaos-to-one-paste-magic-part-2-evolving-templates-into-an-enterprise-library/"
 ---
 In Part 1, I walked through how messy the repo had become and how I normalized everything. But cleanup was just the start. The real milestone came when I took @ryancarson's excellent template foundation and evolved it into a 22-document enterprise-grade library that any CTO would be happy to run their teams on.
 

--- a/marketplace/src/content/blog-posts/ai-dev-transformation-part-3-one-paste-magic.md
+++ b/marketplace/src/content/blog-posts/ai-dev-transformation-part-3-one-paste-magic.md
@@ -4,6 +4,7 @@ description: "How I turned 22 enterprise templates into a one-paste Claude pipel
 date: "2025-09-17"
 tags: ["ai-development", "documentation", "developer-tools", "claude", "cursor", "automation", "workflow"]
 featured: false
+canonical: "https://startaitools.com/posts/from-chaos-to-one-paste-magic-part-3-from-templates-to-one-paste-magic/"
 ---
 In the first two parts of this series, we took the repo from a messy, complex setup into a clean foundation with 22 enterprise-grade documents. Now, we flip the switch: this repo isn't just a library of templates anymore — it's a working AI-powered documentation pipeline.
 

--- a/marketplace/src/content/blog-posts/ai-dev-transformation-part-4-dual-ai-workflows.md
+++ b/marketplace/src/content/blog-posts/ai-dev-transformation-part-4-dual-ai-workflows.md
@@ -4,6 +4,7 @@ description: "The finale: How Claude and Cursor create a complete AI development
 date: "2025-09-17"
 tags: ["ai-development", "documentation", "developer-tools", "claude", "cursor", "future-of-development", "workflow"]
 featured: false
+canonical: "https://startaitools.com/posts/from-chaos-to-one-paste-magic-part-4-dual-ai-workflows-claude-meets-cursor/"
 ---
 Once the repo was simplified and the 22-document suite completed, the next step was distribution. How could developers actually use this without friction?
 

--- a/marketplace/src/content/blog-posts/anti-slop-framework-found-three-bugs-inside-itself.md
+++ b/marketplace/src/content/blog-posts/anti-slop-framework-found-three-bugs-inside-itself.md
@@ -4,6 +4,7 @@ description: "A 41-gate anti-slop framework shipped v0.1.0, then found three sil
 date: "2026-05-03"
 tags: ["oss-contribution", "bash", "gh-cli", "yaml", "silent-failures", "release-engineering", "claude-code-skills"]
 featured: false
+canonical: "https://startaitools.com/posts/anti-slop-framework-found-three-bugs-inside-itself/"
 ---
 A framework whose entire purpose is to catch silent failures in AI-generated OSS contributions is the worst possible place to host silent failures. That tension is the spine of this case study. The framework in question is `contributing-clanker`, an installable Claude Code skill that walks an OSS contribution lifecycle through 41 deterministic gates spanning seven phases and 62 enumerated AI-slop failure modes. It shipped at v0.1.0 around 20:20 local time. By the end of the same day it was at v0.1.2 — because the first real qualifying flow against a third-party upstream (`secureblue/secureblue#2138`) surfaced **three categorically named bash/CLI silent-failure modes** inside the framework itself, plus a minor scoping bug already patched in v0.1.1.
 

--- a/marketplace/src/content/blog-posts/architecting-production-multi-agent-ai-platform-technical-leadership.md
+++ b/marketplace/src/content/blog-posts/architecting-production-multi-agent-ai-platform-technical-leadership.md
@@ -4,6 +4,7 @@ description: "Architecting a Production Multi-Agent AI Platform: Technical Leade
 date: "2025-10-29"
 tags: ["technical-leadership", "cloud-architecture", "ai-systems", "cost-optimization", "infrastructure-automation", "problem-solving"]
 featured: false
+canonical: "https://startaitools.com/posts/architecting-a-production-multi-agent-ai-platform-technical-leadership-in-action/"
 ---
 # Architecting a Production Multi-Agent AI Platform: Technical Leadership in Action
 

--- a/marketplace/src/content/blog-posts/audit-harness-v010-enforcement-travels-with-code.md
+++ b/marketplace/src/content/blog-posts/audit-harness-v010-enforcement-travels-with-code.md
@@ -4,6 +4,7 @@ description: "Testing policy enforcement that lives in ~/.claude/ cannot travel 
 date: "2026-04-21"
 tags: ["testing", "ci-cd", "architecture", "release-engineering", "devops", "automation", "monorepo", "typescript"]
 featured: false
+canonical: "https://startaitools.com/posts/audit-harness-v010-enforcement-travels-with-code/"
 ---
 Testing policy that lives in `~/.claude/` is testing policy that dies on a fresh clone.
 

--- a/marketplace/src/content/blog-posts/automating-developer-workflows-custom-ai-commands.md
+++ b/marketplace/src/content/blog-posts/automating-developer-workflows-custom-ai-commands.md
@@ -4,6 +4,7 @@ description: "Automating Developer Workflows: Building Custom AI Command Systems
 date: "2025-09-27"
 tags: ["automation", "developer-tools", "workflow", "ai", "professional-development"]
 featured: false
+canonical: "https://startaitools.com/posts/automating-developer-workflows-building-custom-ai-command-systems/"
 ---
 Building custom automation tools that transform how developers document and share their work. Today's project: creating intelligent slash commands that analyze project context and generate technical content automatically.
 

--- a/marketplace/src/content/blog-posts/backlog-zero-estate-triage-machine.md
+++ b/marketplace/src/content/blog-posts/backlog-zero-estate-triage-machine.md
@@ -4,6 +4,7 @@ description: "How a wave-based triage machine burned an estate backlog from 973 
 date: "2026-07-02"
 tags: ["backlog", "triage", "devops", "automation", "process", "backlog-management"]
 featured: false
+canonical: "https://startaitools.com/posts/backlog-zero-estate-triage-machine/"
 ---
 A backlog becomes impossible when you treat every issue as its own transaction. The remedy isn't faster triage — it's a **wave-based triage machine**: batch → gate → manifest → verify → repeat.
 

--- a/marketplace/src/content/blog-posts/brand-consistency-css-variables-sponsor-page-redesign.md
+++ b/marketplace/src/content/blog-posts/brand-consistency-css-variables-sponsor-page-redesign.md
@@ -4,6 +4,7 @@ description: "How to migrate a sponsor page from inconsistent hardcoded colors t
 date: "2025-12-02"
 tags: ["css", "design-systems", "frontend", "astro", "branding", "web-development"]
 featured: false
+canonical: "https://startaitools.com/posts/implementing-brand-consistency-with-css-variables-a-sponsor-page-redesign/"
 ---
 When your sponsor page looks like it belongs to a different website than your homepage, you have a brand consistency problem. Here's how I fixed it—and what I learned about the iterative process of design system migration.
 

--- a/marketplace/src/content/blog-posts/braves-booth-dashboard-ui-refactor-ai-pitcher-narrative.md
+++ b/marketplace/src/content/blog-posts/braves-booth-dashboard-ui-refactor-ai-pitcher-narrative.md
@@ -4,6 +4,7 @@ description: "Refactoring the Braves broadcast dashboard idle view, eliminating 
 date: "2026-04-03"
 tags: ["react", "typescript", "full-stack", "ai-agents", "architecture"]
 featured: false
+canonical: "https://startaitools.com/posts/braves-booth-dashboard-ui-refactor-ai-pitcher-narrative/"
 ---
 Between games, the Braves Booth dashboard used to show a tab bar with RECAP and PREVIEW buttons. Pick one. The problem: announcers don't want to choose. They want the full picture — what just happened and what's coming next — on a single screen with no clicks.
 

--- a/marketplace/src/content/blog-posts/braves-booth-v1-release-player-drilldown.md
+++ b/marketplace/src/content/blog-posts/braves-booth-v1-release-player-drilldown.md
@@ -4,6 +4,7 @@ description: "Shipping v1.0.0 of Braves Booth Intelligence — a real-time broad
 date: "2026-04-04"
 tags: ["full-stack", "react", "typescript", "architecture", "debugging", "release-engineering"]
 featured: false
+canonical: "https://startaitools.com/posts/braves-booth-v1-release-player-drilldown/"
 ---
 Braves Booth Intelligence is a real-time broadcast operations tool for Atlanta Braves radio. It pulls live game data from MLB's GUMBO API, runs it through narrative generation, and surfaces radio-ready intel — matchup histories, milestone watches, pitching trends, bio nuggets — on a dashboard the broadcast team uses during games.
 

--- a/marketplace/src/content/blog-posts/braves-postgame-expansion-and-two-ai-lessons.md
+++ b/marketplace/src/content/blog-posts/braves-postgame-expansion-and-two-ai-lessons.md
@@ -4,6 +4,7 @@ description: "Two AI product lessons from the Braves dashboard post-game expansi
 date: "2026-04-18"
 tags: ["braves-booth", "llm", "ai-engineering", "product-design", "full-stack", "rss"]
 featured: false
+canonical: "https://startaitools.com/posts/braves-postgame-expansion-and-two-ai-lessons/"
 ---
 A live broadcast tool shouldn't die the moment the final out is recorded. Audiences stick around. They pull up YouTube for the post-game press conference that uploads 20 minutes later. They tune into podcasts, scroll Reddit threads, check what beat reporters and fans are saying on X. Your dashboard should meet them there.
 

--- a/marketplace/src/content/blog-posts/braves-prewarm-narratives-plus-cc-plugins-community-pr.md
+++ b/marketplace/src/content/blog-posts/braves-prewarm-narratives-plus-cc-plugins-community-pr.md
@@ -4,6 +4,7 @@ description: "Pre-warming AI narratives so viewers never see spinners, feeding s
 date: "2026-04-17"
 tags: ["braves-booth", "llm", "claude-code-plugins", "open-source", "release-engineering"]
 featured: false
+canonical: "https://startaitools.com/posts/braves-prewarm-narratives-plus-cc-plugins-community-pr/"
 ---
 Two repos, two small wins.
 

--- a/marketplace/src/content/blog-posts/broadcast-day-llm-fallback-jchads-challenge.md
+++ b/marketplace/src/content/blog-posts/broadcast-day-llm-fallback-jchads-challenge.md
@@ -4,6 +4,7 @@ description: "Groq quota died 44 minutes before a live broadcast. The fix was a 
 date: "2026-04-29"
 tags: ["ai-agents", "ai-engineering", "architecture", "claude-code", "devops", "sports"]
 featured: false
+canonical: "https://startaitools.com/posts/broadcast-day-llm-fallback-jchads-challenge/"
 ---
 ## TL;DR
 

--- a/marketplace/src/content/blog-posts/building-254-table-bigquery-schema-72-hours.md
+++ b/marketplace/src/content/blog-posts/building-254-table-bigquery-schema-72-hours.md
@@ -4,6 +4,7 @@ description: "How we architected and deployed a massive 254-table BigQuery schem
 date: "2025-09-08"
 tags: ["bigquery", "data-architecture", "google-cloud-platform", "python", "data-engineering"]
 featured: false
+canonical: "https://startaitools.com/posts/building-a-254-table-bigquery-schema-in-72-hours/"
 ---
 ## The Challenge: Zero to Production in 72 Hours
 

--- a/marketplace/src/content/blog-posts/building-cad-dxf-agent-from-zero-to-v010.md
+++ b/marketplace/src/content/blog-posts/building-cad-dxf-agent-from-zero-to-v010.md
@@ -4,6 +4,7 @@ description: "How I built a local-first desktop application that lets a structur
 date: "2026-02-14"
 tags: ["ai-agents", "cad", "dxf", "architecture", "typescript", "llm-integration"]
 featured: false
+canonical: "https://startaitools.com/posts/building-cad-dxf-agent-from-zero-to-v010/"
 ---
 ## The Problem
 

--- a/marketplace/src/content/blog-posts/building-idempotent-stripe-billing-enforcement-firestore.md
+++ b/marketplace/src/content/blog-posts/building-idempotent-stripe-billing-enforcement-firestore.md
@@ -4,6 +4,7 @@ description: "How we built a unified plan enforcement engine that handles duplic
 date: "2025-11-17"
 tags: ["stripe", "firebase", "firestore", "billing", "webhooks", "testing", "typescript", "vitest"]
 featured: false
+canonical: "https://startaitools.com/posts/building-an-idempotent-stripe-billing-enforcement-engine-for-firestore/"
 ---
 When you're building subscription billing with Stripe webhooks, you quickly discover a harsh reality: **webhooks can arrive delayed, duplicated, or out of order**. For a youth sports stats SaaS platform I'm building, this created a critical problem—plan and status updates were scattered across multiple handlers with no guarantee of consistency.
 

--- a/marketplace/src/content/blog-posts/building-moat-auth-persistence-onchain-receipts-117-tests.md
+++ b/marketplace/src/content/blog-posts/building-moat-auth-persistence-onchain-receipts-117-tests.md
@@ -4,6 +4,7 @@ description: "How I built a policy-enforced execution layer for AI agents with H
 date: "2026-02-21"
 tags: ["security", "authentication", "testing", "python", "ci-cd", "blockchain", "proxy"]
 featured: false
+canonical: "https://startaitools.com/posts/building-moat-auth-persistence-onchain-receipts-117-tests/"
 ---
 ## What Moat Does
 

--- a/marketplace/src/content/blog-posts/building-multi-brand-rss-validation-system-97-feeds-tested.md
+++ b/marketplace/src/content/blog-posts/building-multi-brand-rss-validation-system-97-feeds-tested.md
@@ -4,6 +4,7 @@ description: "A complete walkthrough of building and validating an RSS feed dist
 date: "2025-10-03"
 tags: ["rss-feeds", "automation", "data-validation", "bash-scripting", "content-distribution", "n8n", "system-architecture", "problem-solving"]
 featured: false
+canonical: "https://startaitools.com/posts/building-a-multi-brand-rss-validation-system-testing-97-feeds-learning-hard-lessons/"
 ---
 ## The Problem: Building Content Distribution Without Data Validation
 

--- a/marketplace/src/content/blog-posts/building-multi-platform-developer-tools.md
+++ b/marketplace/src/content/blog-posts/building-multi-platform-developer-tools.md
@@ -4,6 +4,7 @@ description: "Building Multi-Platform Developer Tools: Scaling an Open-Source Pr
 date: "2025-09-27"
 tags: ["open-source", "developer-tools", "automation", "technical-leadership"]
 featured: false
+canonical: "https://startaitools.com/posts/building-multi-platform-developer-tools-scaling-an-open-source-project-from-1-to-5-platforms/"
 ---
 ## The Challenge
 

--- a/marketplace/src/content/blog-posts/building-post-compaction-recovery-beads.md
+++ b/marketplace/src/content/blog-posts/building-post-compaction-recovery-beads.md
@@ -4,6 +4,7 @@ description: "How to solve the context loss problem in AI agent workflows using 
 date: "2025-12-28"
 tags: ["ai-development", "task-tracking", "agent-workflows", "git", "automation", "claude-code"]
 featured: false
+canonical: "https://startaitools.com/posts/building-post-compaction-recovery-for-ai-agent-workflows-with-beads/"
 ---
 When Claude Code compacts (summarizes) conversations, you lose critical context about what you were working on. Here's how I solved that problem with a git-based task persistence system - and the debugging journey that made it work.
 

--- a/marketplace/src/content/blog-posts/building-production-multi-agent-ai-brightstream-vertex-ai.md
+++ b/marketplace/src/content/blog-posts/building-production-multi-agent-ai-brightstream-vertex-ai.md
@@ -4,6 +4,7 @@ description: "The real journey from concept to production: building BrightStream
 date: "2025-10-30"
 tags: ["vertex-ai", "ai-agents", "google-cloud", "adk", "multi-agent-systems", "cost-optimization", "docker", "infrastructure-as-code"]
 featured: false
+canonical: "https://startaitools.com/posts/building-a-production-multi-agent-ai-system-brightstreams-10-agent-architecture-on-vertex-ai/"
 ---
 # Building a Production Multi-Agent AI System: BrightStream's 10-Agent Architecture on Vertex AI
 

--- a/marketplace/src/content/blog-posts/building-production-ready-research-tool-outperforms-anthropic.md
+++ b/marketplace/src/content/blog-posts/building-production-ready-research-tool-outperforms-anthropic.md
@@ -4,6 +4,7 @@ description: "How I Built a Production-Ready Research Tool That Outperforms Anth
 date: "2025-10-20"
 tags: ["typescript", "mcp", "open-source", "product-development", "api-design"]
 featured: false
+canonical: "https://startaitools.com/posts/how-i-built-a-production-ready-research-tool-that-outperforms-anthropics-solution/"
 ---
 On October 20, 2025, Anthropic announced Claude for Life Sciences - a suite of research tools for scientific literature. That same evening, I built something better: a production-ready PubMed research toolkit with 10 MCP tools, comprehensive test coverage, and zero security vulnerabilities.
 

--- a/marketplace/src/content/blog-posts/cap-drop-all-broke-the-gate-socket.md
+++ b/marketplace/src/content/blog-posts/cap-drop-all-broke-the-gate-socket.md
@@ -4,6 +4,7 @@ description: "Hardening a container hid a permission bug: --cap-drop ALL strippe
 date: "2026-06-12"
 tags: ["docker", "debugging", "ai-agents", "devops", "ci-cd"]
 featured: false
+canonical: "https://startaitools.com/posts/cap-drop-all-broke-the-gate-socket/"
 ---
 The dogfood run went green. The gate had governed zero calls.
 

--- a/marketplace/src/content/blog-posts/ccsc-five-releases-one-day-security-sprint.md
+++ b/marketplace/src/content/blog-posts/ccsc-five-releases-one-day-security-sprint.md
@@ -4,6 +4,7 @@ description: "Epic 29-A, 30-A, 30-B, 32-B land in a single calendar day across v
 date: "2026-04-19"
 tags: ["claude-code", "security", "release-engineering", "typescript", "architecture", "testing", "ai-agents"]
 featured: false
+canonical: "https://startaitools.com/posts/ccsc-five-releases-one-day-security-sprint/"
 ---
 Four releases in one day is what happens when a security audit turns productive.
 

--- a/marketplace/src/content/blog-posts/checkout-image-volume-three-way-drift.md
+++ b/marketplace/src/content/blog-posts/checkout-image-volume-three-way-drift.md
@@ -4,6 +4,7 @@ description: "A rebuild succeeded and nothing changed. How Docker named volumes 
 date: "2026-07-26"
 tags: ["deployment", "docker", "ci", "devops", "named-volumes", "smoke-testing", "verification"]
 featured: false
+canonical: "https://startaitools.com/posts/checkout-image-volume-three-way-drift/"
 ---
 A rebuild succeeded. Docker reported healthy. The site served the same bytes it had been serving for weeks.
 

--- a/marketplace/src/content/blog-posts/coasean-singularity-ai-agents-market-transformation.md
+++ b/marketplace/src/content/blog-posts/coasean-singularity-ai-agents-market-transformation.md
@@ -4,6 +4,7 @@ description: "Analysis of groundbreaking NBER research on how autonomous AI agen
 date: "2025-10-24"
 tags: ["ai-agents", "economics", "market-design", "transaction-costs", "nber-research"]
 featured: false
+canonical: "https://startaitools.com/posts/the-coasean-singularity-how-ai-agents-will-transform-digital-markets/"
 ---
 ## Executive Summary
 

--- a/marketplace/src/content/blog-posts/coherence-day-drift-detection-strategic-spine.md
+++ b/marketplace/src/content/blog-posts/coherence-day-drift-detection-strategic-spine.md
@@ -4,6 +4,7 @@ description: "Why scattered Plane issues, beads, docs, and partner portals silen
 date: "2026-05-08"
 tags: ["claude-code", "architecture", "ai-agents", "release-engineering"]
 featured: false
+canonical: "https://startaitools.com/posts/coherence-day-drift-detection-strategic-spine/"
 ---
 A sprawling multi-surface engagement (Kobiton partner pilot, 4 months, three deliverable rounds) exposed a silent failure mode: drift doesn't announce itself. A title rename on Plane goes unnoticed when the canonical source doc still has the old framing. A partner-portal deliverable gets updated before the source file does, leaving future sessions reading stale context from what should be source-of-truth.
 

--- a/marketplace/src/content/blog-posts/comprehensive-technical-guide-to-ssh-debian-packages-and-grep.md
+++ b/marketplace/src/content/blog-posts/comprehensive-technical-guide-to-ssh-debian-packages-and-grep.md
@@ -4,6 +4,7 @@ description: "Comprehensive Technical Guide to SSH, Debian Packages, and Grep"
 date: "2025-01-13"
 tags: ["start-ai-tools"]
 featured: false
+canonical: "https://startaitools.com/posts/comprehensive-technical-guide-to-ssh-debian-packages-and-grep/"
 ---
 <p><em>This comprehensive technical guide was developed with assistance from ScholarGPT and GPT-5, providing graduate-level coverage of essential Linux administration tools.</em></p>
 <h2 id="-comprehensive-technical-guide-to-ssh-debian-packages-and-grep">

--- a/marketplace/src/content/blog-posts/content-quality-war-7-check-audit-across-340-plugins.md
+++ b/marketplace/src/content/blog-posts/content-quality-war-7-check-audit-across-340-plugins.md
@@ -4,6 +4,7 @@ description: "A 7-category audit script found boilerplate openings, empty shells
 date: "2026-03-17"
 tags: ["claude-code", "automation", "ci-cd", "architecture", "web-development"]
 featured: false
+canonical: "https://startaitools.com/posts/content-quality-war-7-check-audit-across-340-plugins/"
 ---
 Every plugin had content. Most of it was junk.
 

--- a/marketplace/src/content/blog-posts/coppa-compliance-youth-sports-app-real-implementation-process.md
+++ b/marketplace/src/content/blog-posts/coppa-compliance-youth-sports-app-real-implementation-process.md
@@ -4,6 +4,7 @@ description: "A complete walkthrough of implementing COPPA-compliant legal frame
 date: "2025-10-08"
 tags: ["compliance", "coppa", "legal", "nextjs", "prisma", "cloud-run", "database-migrations", "production", "deployment"]
 featured: false
+canonical: "https://startaitools.com/posts/making-a-youth-sports-app-coppa-compliant-the-real-process-from-question-to-production/"
 ---
 When you're building an app that tracks data for children under 13, there's a moment where you realize: this needs to be legally bulletproof before it sees a single real user. For Hustle, our youth soccer statistics tracking platform, that moment came today.
 

--- a/marketplace/src/content/blog-posts/copying-files-is-not-installing.md
+++ b/marketplace/src/content/blog-posts/copying-files-is-not-installing.md
@@ -4,6 +4,7 @@ description: "A marketplace install copies a plugin's files into place but never
 date: "2026-07-16"
 tags: ["claude-code", "plugins", "mcp", "nodejs", "packaging", "npm", "native-modules"]
 featured: false
+canonical: "https://startaitools.com/posts/copying-files-is-not-installing/"
 ---
 A marketplace install copies your plugin's files into place. It does not run `npm install` in them. Those are two different operations, and the gap between them is where "works on my machine" lives.
 

--- a/marketplace/src/content/blog-posts/coverage-vs-mutation-testing-rules-engine.md
+++ b/marketplace/src/content/blog-posts/coverage-vs-mutation-testing-rules-engine.md
@@ -4,6 +4,7 @@ description: "A repo at 69% line coverage scored 24.88% on mutation testing—an
 date: "2026-06-28"
 tags: ["testing", "typescript", "ci-cd", "devops", "automation"]
 featured: false
+canonical: "https://startaitools.com/posts/coverage-vs-mutation-testing-rules-engine/"
 ---
 Sunday 2026-06-28. intent-mail repo, fresh Stryker baseline run. The coverage gate reported green: 69.09% line coverage. Three seconds later, mutation testing reported 24.88%. The rules engine—the code that actually mutates user email—reported 0.00%.
 

--- a/marketplace/src/content/blog-posts/debugging-claude-code-slash-commands-silent-deployment-failures.md
+++ b/marketplace/src/content/blog-posts/debugging-claude-code-slash-commands-silent-deployment-failures.md
@@ -4,6 +4,7 @@ description: "A forensic investigation into why Claude Code slash commands were 
 date: "2025-10-03"
 tags: ["claude-code", "debugging", "automation", "slash-commands", "git-workflow", "hugo", "taskwarrior"]
 featured: false
+canonical: "https://startaitools.com/posts/debugging-claude-code-slash-commands-when-your-blog-automation-silently-fails/"
 ---
 ## The Mystery: Content Created, But Never Published
 

--- a/marketplace/src/content/blog-posts/debugging-critical-marketplace-schema-validation-failure.md
+++ b/marketplace/src/content/blog-posts/debugging-critical-marketplace-schema-validation-failure.md
@@ -4,6 +4,7 @@ description: "A critical bug stopped ALL marketplace installations. Here's the c
 date: "2025-10-16"
 tags: ["debugging", "schema-validation", "ci-cd", "marketplace", "claude-code", "github-actions", "legal-compliance"]
 featured: false
+canonical: "https://startaitools.com/posts/debugging-a-critical-marketplace-schema-validation-failure-how-one-invalid-field-blocked-all-installations/"
 ---
 At 10:16 PM ET on October 16th, 2025, a user reported they couldn't install the Claude Code Plugins marketplace. The error message was clear but devastating:
 

--- a/marketplace/src/content/blog-posts/debugging-slack-integration-6-duplicate-responses-instant-acknowledgment.md
+++ b/marketplace/src/content/blog-posts/debugging-slack-integration-6-duplicate-responses-instant-acknowledgment.md
@@ -4,6 +4,7 @@ description: "Real-world debugging of Slack webhook integration causing duplicat
 date: "2025-10-09"
 tags: ["slack-api", "webhook-debugging", "background-processing", "api-integration", "production-debugging"]
 featured: false
+canonical: "https://startaitools.com/posts/debugging-slack-integration-from-6-duplicate-responses-to-instant-acknowledgment/"
 ---
 ## The Problem: Bob Responded 6 Times to Every Message
 

--- a/marketplace/src/content/blog-posts/demo-subdomain-deployment-blockers-existing-pattern.md
+++ b/marketplace/src/content/blog-posts/demo-subdomain-deployment-blockers-existing-pattern.md
@@ -4,6 +4,7 @@ description: "Hit 5 blockers deploying a demo subdomain. Fixed them all by remem
 date: "2026-04-24"
 tags: ["deployment", "devops", "claude-code", "automation", "infrastructure"]
 featured: false
+canonical: "https://startaitools.com/posts/demo-subdomain-deployment-blockers-existing-pattern/"
 ---
 ## The Problem
 

--- a/marketplace/src/content/blog-posts/dependabot-pile-up-fix-the-policy.md
+++ b/marketplace/src/content/blog-posts/dependabot-pile-up-fix-the-policy.md
@@ -4,6 +4,7 @@ description: "15 dependabot PRs piling up? Stop merging individually. Group mino
 date: "2026-07-08"
 tags: ["ci-cd", "devops", "automation", "release-engineering"]
 featured: false
+canonical: "https://startaitools.com/posts/dependabot-pile-up-fix-the-policy/"
 ---
 Guidewire's dependabot backlog hit 15 open PRs by late June. tsx 4.21→4.23. undici 6.25→8.3. @opentelemetry/sdk-node. pg 8.20→8.21. GitHub Actions bumps on checkout, upload-artifact, setup-java, gitleaks-action, cache. All of them CI-green. All of them waiting for a human to click merge.
 

--- a/marketplace/src/content/blog-posts/design-tokens-and-validator-parity-marketplace-foundations.md
+++ b/marketplace/src/content/blog-posts/design-tokens-and-validator-parity-marketplace-foundations.md
@@ -4,6 +4,7 @@ description: "Replacing scattered CSS values with design tokens and realigning t
 date: "2026-03-12"
 tags: ["web-development", "claude-code", "architecture", "ci-cd"]
 featured: false
+canonical: "https://startaitools.com/posts/design-tokens-and-validator-parity-marketplace-foundations/"
 ---
 Five commits today. No new features. Just foundations.
 

--- a/marketplace/src/content/blog-posts/designing-local-first-resume-parser-architecture-edge-ai.md
+++ b/marketplace/src/content/blog-posts/designing-local-first-resume-parser-architecture-edge-ai.md
@@ -4,6 +4,7 @@ description: "Documenting the architecture decisions for Resume Realtime - a pla
 date: "2025-12-11"
 tags: ["rust", "leptos", "wasm", "webgpu", "ai", "architecture", "planning"]
 featured: false
+canonical: "https://startaitools.com/posts/designing-a-local-first-resume-parser-architecture-decisions-for-edge-ai/"
 ---
 ## The Problem I Want to Solve
 

--- a/marketplace/src/content/blog-posts/deterministic-dxf-comparison-engine-one-day-build.md
+++ b/marketplace/src/content/blog-posts/deterministic-dxf-comparison-engine-one-day-build.md
@@ -4,6 +4,7 @@ description: "Four PRs, 5000+ lines, 1875 tests. How to compare two versions of 
 date: "2026-02-26"
 tags: ["ai-agents", "python", "testing", "architecture", "cad"]
 featured: false
+canonical: "https://startaitools.com/posts/deterministic-dxf-comparison-engine-one-day-build/"
 ---
 How do you compare two versions of an engineering drawing when one has been translated, rotated, or just has slightly different coordinate precision?
 

--- a/marketplace/src/content/blog-posts/devops-onboarding-at-scale-comprehensive-system-analysis-universal-templates.md
+++ b/marketplace/src/content/blog-posts/devops-onboarding-at-scale-comprehensive-system-analysis-universal-templates.md
@@ -4,6 +4,7 @@ description: "From creating 20,000-word system analysis documents to solving com
 date: "2025-10-01"
 tags: ["devops", "gcp", "system-analysis", "templates", "documentation", "iam", "cloud-security", "infrastructure"]
 featured: false
+canonical: "https://startaitools.com/posts/devops-onboarding-at-scale-creating-comprehensive-system-analysis-with-universal-templates/"
 ---
 # DevOps Onboarding at Scale: Creating Comprehensive System Analysis with Universal Templates
 

--- a/marketplace/src/content/blog-posts/diagnostic-pro-feature-rollouts-2025.md
+++ b/marketplace/src/content/blog-posts/diagnostic-pro-feature-rollouts-2025.md
@@ -4,6 +4,7 @@ description: "DiagnosticPro: Revolutionary Feature Rollouts Coming This Quarter"
 date: "2025-09-11"
 tags: ["ai", "diagnostics", "features", "video", "audio", "platform"]
 featured: false
+canonical: "https://startaitools.com/posts/diagnosticpro-revolutionary-feature-rollouts-coming-this-quarter/"
 ---
 *Timestamp: 2025-09-11 15:45:00*
 

--- a/marketplace/src/content/blog-posts/diagnosticpro-case-study.md
+++ b/marketplace/src/content/blog-posts/diagnosticpro-case-study.md
@@ -4,6 +4,7 @@ description: "How we built a professional-grade AI vehicle diagnostics platform 
 date: "2025-09-08"
 tags: ["case-study", "ai", "bigquery", "gcp", "python", "rapid-development"]
 featured: false
+canonical: "https://startaitools.com/posts/building-diagnosticpro-ai-powered-vehicle-diagnostics-platform/"
 ---
 ## Executive Summary
 

--- a/marketplace/src/content/blog-posts/distributed-systems-architecture-patterns-cheat-sheet.md
+++ b/marketplace/src/content/blog-posts/distributed-systems-architecture-patterns-cheat-sheet.md
@@ -4,6 +4,7 @@ description: "Distributed Systems Architecture Patterns Cheat Sheet"
 date: "2025-01-13"
 tags: ["start-ai-tools"]
 featured: false
+canonical: "https://startaitools.com/posts/distributed-systems-architecture-patterns-cheat-sheet/"
 ---
 <p>A quick reference guide for distributed systems architecture patterns, covering when to use each pattern and the classic problems they solve.</p>
 <h2 id="distributed-systems-architecture-patterns-cheat-sheet">

--- a/marketplace/src/content/blog-posts/do-not-blindly-restart.md
+++ b/marketplace/src/content/blog-posts/do-not-blindly-restart.md
@@ -4,6 +4,7 @@ description: "A burn-in watchdog latched on a phantom io spike. The fix: fail-cl
 date: "2026-07-20"
 tags: ["observability", "devops", "automation", "architecture"]
 featured: false
+canonical: "https://startaitools.com/posts/do-not-blindly-restart/"
 ---
 A self-healing system that restarts blindly is an outage generator with extra steps.
 

--- a/marketplace/src/content/blog-posts/empty-is-not-clean.md
+++ b/marketplace/src/content/blog-posts/empty-is-not-clean.md
@@ -4,6 +4,7 @@ description: "One fail-open bug, five disguises: empty args, an empty log, a mis
 date: "2026-07-13"
 tags: ["ai-agents", "typescript", "authentication", "architecture", "claude-code", "testing"]
 featured: false
+canonical: "https://startaitools.com/posts/empty-is-not-clean/"
 ---
 A policy said `deny` anything under `/etc`. A Bash call read `/etc/shadow` and came back `{allow, rule: 'trust-bash'}`. No human in the loop. The deny rule was still there, still first in the list, still scoped exactly the way an operator would write it. It just never fired.
 

--- a/marketplace/src/content/blog-posts/engine-to-product-three-interfaces-one-codebase.md
+++ b/marketplace/src/content/blog-posts/engine-to-product-three-interfaces-one-codebase.md
@@ -4,6 +4,7 @@ description: "Building CLI, REST API, and frontend wizard interfaces on top of a
 date: "2026-02-28"
 tags: ["ai-agents", "python", "fastapi", "architecture", "full-stack", "cad"]
 featured: false
+canonical: "https://startaitools.com/posts/engine-to-product-three-interfaces-one-codebase/"
 ---
 You built the engine. Four layers of deterministic comparison, 1,875 tests, confidence scoring, alignment ladder. Great. Nobody can use it.
 

--- a/marketplace/src/content/blog-posts/enterprise-documentation-transformation-git-native-taskwarrior-workflows.md
+++ b/marketplace/src/content/blog-posts/enterprise-documentation-transformation-git-native-taskwarrior-workflows.md
@@ -4,6 +4,7 @@ description: "How to systematically transform production platforms using git-nat
 date: "2025-09-30"
 tags: ["enterprise-architecture", "documentation", "taskwarrior", "git-workflows", "platform-engineering", "technical-leadership"]
 featured: false
+canonical: "https://startaitools.com/posts/enterprise-documentation-transformation-git-native-taskwarrior-workflows-for-platform-reorganization/"
 ---
 # Enterprise Documentation Transformation: From Chaos to Systematic Excellence
 

--- a/marketplace/src/content/blog-posts/enterprise-software-transformation-waygate-mcp-case-study.md
+++ b/marketplace/src/content/blog-posts/enterprise-software-transformation-waygate-mcp-case-study.md
@@ -4,6 +4,7 @@ description: "Enterprise Software Transformation: From Framework to Production S
 date: "2025-09-28"
 tags: ["project-management", "enterprise-software", "security", "professional-development", "technical-leadership"]
 featured: false
+canonical: "https://startaitools.com/posts/enterprise-software-transformation-from-framework-to-production-server-a-project-management-case-study/"
 ---
 How do you transform a foundational software framework into an enterprise-grade production server? Through systematic analysis, professional project management, and methodical execution.
 

--- a/marketplace/src/content/blog-posts/enterprise-workflow-transformation-n8n-tech-intelligence-platform.md
+++ b/marketplace/src/content/blog-posts/enterprise-workflow-transformation-n8n-tech-intelligence-platform.md
@@ -4,6 +4,7 @@ description: "Transforming Complex N8N Workflows: From Analysis to Enterprise Te
 date: "2025-09-28"
 tags: ["portfolio", "enterprise-automation", "technical-analysis", "workflow-optimization", "business-intelligence", "documentation", "project-management"]
 featured: false
+canonical: "https://startaitools.com/posts/transforming-complex-n8n-workflows-from-analysis-to-enterprise-tech-intelligence-platform/"
 ---
 # How I Transformed a Complex N8N Workflow Into an Enterprise Tech Intelligence Platform
 

--- a/marketplace/src/content/blog-posts/eval-gated-model-swap-gpt-5-4.md
+++ b/marketplace/src/content/blog-posts/eval-gated-model-swap-gpt-5-4.md
@@ -4,6 +4,7 @@ description: "Deploy gpt-5.4 to production as a one-line config with eval-gated 
 date: "2026-07-03"
 tags: ["ai-engineering", "openai", "release-engineering", "testing", "devops"]
 featured: false
+canonical: "https://startaitools.com/posts/eval-gated-model-swap-gpt-5-4/"
 ---
 On 2026-07-03, DiagnosticPro shipped gpt-5.4 in production. The structural finding: gpt-4o silently capped reports at ~1,225 words across 36 benchmark runs—no matter the prompt. gpt-5.4 delivers depth. A real stored report came back at 15 sections, 3,393 words.
 

--- a/marketplace/src/content/blog-posts/every-safety-gate-has-a-failure-direction.md
+++ b/marketplace/src/content/blog-posts/every-safety-gate-has-a-failure-direction.md
@@ -4,6 +4,7 @@ description: "Safety gates fail in opposite directions: one crashed fail-closed,
 date: "2026-07-06"
 tags: ["debugging", "ci-cd", "automation", "observability"]
 featured: false
+canonical: "https://startaitools.com/posts/every-safety-gate-has-a-failure-direction/"
 ---
 A deterministic recap tool ran for the first time on a live system. Within hours, its block-event table showed seventeen consecutive BLOCK events. The natural question: what broke? The answer was worse than expected. Two gates in the same codebase were failing in opposite directions, both invisible for the identical reason.
 

--- a/marketplace/src/content/blog-posts/exit-0-is-not-success.md
+++ b/marketplace/src/content/blog-posts/exit-0-is-not-success.md
@@ -4,6 +4,7 @@ description: "A green exit code can hide a dead job. Intent-OS automation assura
 date: "2026-07-14"
 tags: ["automation", "devops", "observability", "ci-cd", "architecture", "testing"]
 featured: false
+canonical: "https://startaitools.com/posts/exit-0-is-not-success/"
 ---
 A cron that exits zero and produces nothing is not healthy. It is a silent failure wearing a green badge.
 

--- a/marketplace/src/content/blog-posts/external-plugin-sync-keeping-community-plugins-fresh.md
+++ b/marketplace/src/content/blog-posts/external-plugin-sync-keeping-community-plugins-fresh.md
@@ -4,6 +4,7 @@ description: "How we built daily automated sync infrastructure to keep community
 date: "2026-01-03"
 tags: ["claude-code", "automation", "github-actions", "open-source", "plugin-marketplace"]
 featured: false
+canonical: "https://startaitools.com/posts/building-external-plugin-sync-how-we-keep-258-community-plugins-fresh/"
 ---
 ## The Problem: Static Forks Go Stale
 

--- a/marketplace/src/content/blog-posts/february-2026-state-of-affairs-255-commits-12-projects.md
+++ b/marketplace/src/content/blog-posts/february-2026-state-of-affairs-255-commits-12-projects.md
@@ -4,6 +4,7 @@ description: "A candid look at 18 days of engineering output: 255+ commits acros
 date: "2026-02-22"
 tags: ["retrospective", "portfolio", "engineering-velocity", "startup"]
 featured: false
+canonical: "https://startaitools.com/posts/february-2026-state-of-affairs-255-commits-12-projects/"
 ---
 ## The Numbers
 

--- a/marketplace/src/content/blog-posts/fine-tuning-iam1-hierarchical-multi-agent-vertex-ai.md
+++ b/marketplace/src/content/blog-posts/fine-tuning-iam1-hierarchical-multi-agent-vertex-ai.md
@@ -4,6 +4,7 @@ description: "Deep dive into fine-tuning a Regional Manager AI agent (IAM1) with
 date: "2025-11-09"
 tags: ["vertex-ai", "multi-agent-systems", "google-adk", "gemini", "agent-orchestration", "iam-architecture"]
 featured: false
+canonical: "https://startaitools.com/posts/fine-tuning-iam1-building-a-hierarchical-multi-agent-system-on-vertex-ai/"
 ---
 ## The Problem: Generic Orchestrator vs Business-Aligned Regional Manager
 

--- a/marketplace/src/content/blog-posts/five-releases-fifteen-minutes-mandy-cutover-and-freeze-break.md
+++ b/marketplace/src/content/blog-posts/five-releases-fifteen-minutes-mandy-cutover-and-freeze-break.md
@@ -4,6 +4,7 @@ description: "A mandy dashboard cutover surfaced four cross-layer deploy gotchas
 date: "2026-05-02"
 tags: ["release-engineering", "devops", "systemd", "ci-cd", "monorepo"]
 featured: false
+canonical: "https://startaitools.com/posts/five-releases-fifteen-minutes-mandy-cutover-and-freeze-break/"
 ---
 Two release cadences collided on the same day. One was a thoughtful CI redesign that finally broke a four-month npm publish freeze across 400+ packages — good engineering, well-trodden ground. The other was a fifteen-minute production firefight on `mandy.intentsolutions.io` that surfaced four cross-layer deploy gotchas you would never know to look for until they hit you. Five releases in fifteen minutes, six commits, four production fixes, and a sixth release for the next layer of the system. The firefight is the one worth keeping in your runbook.
 

--- a/marketplace/src/content/blog-posts/five-silent-failures-one-day.md
+++ b/marketplace/src/content/blog-posts/five-silent-failures-one-day.md
@@ -4,6 +4,7 @@ description: "Five tools said PASS without doing the work — pr-prescreen, .git
 date: "2026-05-16"
 tags: ["ci-cd", "debugging", "devops", "claude-code", "release-engineering"]
 featured: false
+canonical: "https://startaitools.com/posts/five-silent-failures-one-day/"
 ---
 **A silent failure is when a tool reports PASS without doing the work it was supposed to do — the legitimate empty-set case and the broken-but-silent case produce identical output, and nothing downstream can tell them apart.**
 

--- a/marketplace/src/content/blog-posts/fixing-claude-code-eacces-multi-user-linux-permissions.md
+++ b/marketplace/src/content/blog-posts/fixing-claude-code-eacces-multi-user-linux-permissions.md
@@ -4,6 +4,7 @@ description: "Deep dive into debugging and fixing Claude Code EACCES permission 
 date: "2025-10-23"
 tags: ["claude-code", "linux", "permissions", "multi-user", "debugging", "troubleshooting"]
 featured: false
+canonical: "https://startaitools.com/posts/fixing-claude-code-eacces-multi-user-linux-permission-architecture/"
 ---
 When you're running Claude Code across multiple Linux user accounts and hit `EACCES: permission denied`, the solution isn't just `chmod 777`. This is the complete troubleshooting journey from error to production-ready multi-user architecture.
 

--- a/marketplace/src/content/blog-posts/fixing-claude-code-hooks-new-matcher-format.md
+++ b/marketplace/src/content/blog-posts/fixing-claude-code-hooks-new-matcher-format.md
@@ -4,6 +4,7 @@ description: "Fixing Claude Code Hooks: The New Matcher Format"
 date: "2026-02-04"
 tags: ["claude-code", "debugging", "configuration", "hooks"]
 featured: false
+canonical: "https://startaitools.com/posts/fixing-claude-code-hooks-the-new-matcher-format/"
 ---
 Claude Code recently changed their hooks format, and if you haven't updated your project settings, you'll see this cryptic error:
 

--- a/marketplace/src/content/blog-posts/fixing-provider-registry-mutations-sandbox-permissions.md
+++ b/marketplace/src/content/blog-posts/fixing-provider-registry-mutations-sandbox-permissions.md
@@ -4,6 +4,7 @@ description: "How a mutable global registry caused shared state corruption acros
 date: "2026-02-15"
 tags: ["debugging", "typescript", "zod", "registry-pattern", "sandbox", "git-with-intent"]
 featured: false
+canonical: "https://startaitools.com/posts/fixing-provider-registry-mutations-sandbox-permissions/"
 ---
 ## The Bug: Global State Corruption
 

--- a/marketplace/src/content/blog-posts/flops-correction-unchecked-derivation-peer-review.md
+++ b/marketplace/src/content/blog-posts/flops-correction-unchecked-derivation-peer-review.md
@@ -4,6 +4,7 @@ description: "A 35x FLOPs correction in pre-filing patent artifacts validated th
 date: "2026-04-15"
 tags: ["architecture", "release-engineering", "code-quality", "ai-agents", "claude-code", "automation", "supply-chain-security"]
 featured: false
+canonical: "https://startaitools.com/posts/flops-correction-unchecked-derivation-peer-review/"
 ---
 Peer review is not paperwork. When a reviewer tells you "unchecked derivations are your highest-risk failure class," they are handing you the exact failure that will bite you if you skip the checklist.
 

--- a/marketplace/src/content/blog-posts/forge-dogfood-plane-plugin-grade-a-and-jrig-verified-loop.md
+++ b/marketplace/src/content/blog-posts/forge-dogfood-plane-plugin-grade-a-and-jrig-verified-loop.md
@@ -4,6 +4,7 @@ description: "First end-to-end /skill-creator --forge dogfood produced a Grade A
 date: "2026-05-07"
 tags: ["claude-code", "ai-agents", "automation", "release-engineering", "architecture"]
 featured: false
+canonical: "https://startaitools.com/posts/forge-dogfood-plane-plugin-grade-a-and-jrig-verified-loop/"
 ---
 A plugin generator is theoretical until it produces something a marketplace will actually accept. May 7 turned the `/skill-creator --forge` workflow from an 8-gate diagram into a real artifact — a Plane plugin that scored Grade A (97/100), passed Tier 2 GREEN with zero warnings, and cleared all 12 deterministic j-rig checks across the 7-layer behavioral framework. On the same day, the JRig-Verified provenance pipe closed end-to-end: a schema, a build-time enrichment step, a per-plugin verification page, and a validator tier all landed in the same window. The thesis the day proves: compound commands and build-time enrichment beat raw API surfaces and runtime joins, and the way to find that out is to run the full pipeline once on something real.
 

--- a/marketplace/src/content/blog-posts/from-tool-to-platform-intentcad-five-epics-one-day.md
+++ b/marketplace/src/content/blog-posts/from-tool-to-platform-intentcad-five-epics-one-day.md
@@ -4,6 +4,7 @@ description: "cad-dxf-agent becomes IntentCAD. Multi-user auth, intent routing, 
 date: "2026-03-06"
 tags: ["ai-agents", "architecture", "python", "authentication", "full-stack"]
 featured: false
+canonical: "https://startaitools.com/posts/from-tool-to-platform-intentcad-five-epics-one-day/"
 ---
 The DXF comparison tool is dead. Long live IntentCAD.
 

--- a/marketplace/src/content/blog-posts/gate-the-statement-not-the-tool-name.md
+++ b/marketplace/src/content/blog-posts/gate-the-statement-not-the-tool-name.md
@@ -4,6 +4,7 @@ description: "When one MCP tool carries every SQL verb, allowlisting tool names 
 date: "2026-06-29"
 tags: ["ai-agents", "claude-code", "security", "mcp", "architecture"]
 featured: false
+canonical: "https://startaitools.com/posts/gate-the-statement-not-the-tool-name/"
 ---
 The original safety gate on the Dolt-over-MCP plugin tried to keep a Claude Code agent harmless by excluding "history-affecting tools" from its MCP grant. It was the wrong granularity, and it did nothing.
 

--- a/marketplace/src/content/blog-posts/gemini-pr-review-silent-fail-cross-repo-triangulation.md
+++ b/marketplace/src/content/blog-posts/gemini-pr-review-silent-fail-cross-repo-triangulation.md
@@ -4,6 +4,7 @@ description: "When a Gemini PR review workflow silently fails for four months, y
 date: "2026-04-23"
 tags: ["ai-agents", "debugging", "ci-cd", "claude-code", "github-actions"]
 featured: false
+canonical: "https://startaitools.com/posts/gemini-pr-review-silent-fail-cross-repo-triangulation/"
 ---
 When an integration silently fails for months, your first-principles hypothesis is the suspect — find a working reference implementation in the same ecosystem and triangulate against its actual configuration before committing to a fix.
 

--- a/marketplace/src/content/blog-posts/git-with-intent-v090-v0100-docker-upgrades.md
+++ b/marketplace/src/content/blog-posts/git-with-intent-v090-v0100-docker-upgrades.md
@@ -4,6 +4,7 @@ description: "Two releases in one week: Docker Node 22 LTS upgrades across 7 ser
 date: "2026-02-19"
 tags: ["release-engineering", "docker", "node-22", "documentation", "developer-experience", "git-with-intent"]
 featured: false
+canonical: "https://startaitools.com/posts/git-with-intent-v090-v0100-docker-upgrades/"
 ---
 ## Two Releases in a Week
 

--- a/marketplace/src/content/blog-posts/github-release-workflow-uncommitted-changes-semantic-versioning.md
+++ b/marketplace/src/content/blog-posts/github-release-workflow-uncommitted-changes-semantic-versioning.md
@@ -4,6 +4,7 @@ description: "A real-world walkthrough of diagnosing uncommitted changes, applyi
 date: "2025-10-03"
 tags: ["github", "release-management", "version-control", "git-workflow", "semantic-versioning", "ci-cd"]
 featured: false
+canonical: "https://startaitools.com/posts/github-release-workflow-when-yesterdays-updates-arent-public-and-how-we-fixed-it/"
 ---
 ## The Question That Started Everything
 

--- a/marketplace/src/content/blog-posts/github-repos-to-published-education-documentation-transformation.md
+++ b/marketplace/src/content/blog-posts/github-repos-to-published-education-documentation-transformation.md
@@ -4,6 +4,7 @@ description: "How we discovered 31KB of premium educational content buried in pr
 date: "2025-10-07"
 tags: ["content-strategy", "educational-content", "documentation", "open-source", "platform-engineering"]
 featured: false
+canonical: "https://startaitools.com/posts/from-github-repos-to-published-education-transforming-hidden-documentation-into-31kb-of-live-content/"
 ---
 # From GitHub Repos to Published Education: Transforming Hidden Documentation
 

--- a/marketplace/src/content/blog-posts/golden-tests-fuzz-testing-dxf-revision-corpus.md
+++ b/marketplace/src/content/blog-posts/golden-tests-fuzz-testing-dxf-revision-corpus.md
@@ -4,6 +4,7 @@ description: "Building a test corpus with clean/nasty fixture taxonomy, golden f
 date: "2026-02-27"
 tags: ["testing", "python", "architecture", "ai-agents", "cad"]
 featured: false
+canonical: "https://startaitools.com/posts/golden-tests-fuzz-testing-dxf-revision-corpus/"
 ---
 Yesterday I shipped a [deterministic DXF comparison engine](/blog/deterministic-dxf-comparison-engine-one-day-build/) — canonical models, alignment ladders, confidence scoring, the works. Four PRs, 814 tests, all green.
 

--- a/marketplace/src/content/blog-posts/governed-knowledge-two-releases-freshness-daemon.md
+++ b/marketplace/src/content/blog-posts/governed-knowledge-two-releases-freshness-daemon.md
@@ -4,6 +4,7 @@ description: "qmd-team-intent-kb ships v0.2.0 and v0.3.0 in one day — freshnes
 date: "2026-03-19"
 tags: ["typescript", "architecture", "release-engineering", "ai-agents", "claude-code"]
 featured: false
+canonical: "https://startaitools.com/posts/governed-knowledge-two-releases-freshness-daemon/"
 ---
 Yesterday we built the knowledge base from zero to API. Today we shipped it twice.
 

--- a/marketplace/src/content/blog-posts/groq-cloud-run-env-star-refresh.md
+++ b/marketplace/src/content/blog-posts/groq-cloud-run-env-star-refresh.md
@@ -4,6 +4,7 @@ description: "Three quick fixes across three repos — a missing env var that br
 date: "2026-04-12"
 tags: ["devops", "automation"]
 featured: false
+canonical: "https://startaitools.com/posts/groq-cloud-run-env-star-refresh/"
 ---
 Production was calling Vertex AI. It was supposed to call Groq.
 

--- a/marketplace/src/content/blog-posts/guidewire-mcp-v0-1-0-foundation-ship.md
+++ b/marketplace/src/content/blog-posts/guidewire-mcp-v0-1-0-foundation-ship.md
@@ -4,6 +4,7 @@ description: "How v0.1.0 of guidewire-mcp-for-claude shipped six foundation pack
 date: "2026-05-04"
 tags: ['mcp', 'enterprise-integration', 'guidewire', 'architecture', 'claude-code']
 featured: false
+canonical: "https://startaitools.com/posts/guidewire-mcp-v0-1-0-foundation-ship/"
 ---
 
 [Guidewire MCP for Claude](https://github.com/jeremylongshore/guidewire-mcp-for-claude) v0.1.0 is a carrier-native [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server that lets a Claude Code session ask a Guidewire PolicyCenter, BillingCenter, or ClaimCenter tenant questions in the language an underwriter or claims handler would actually use — `find-submissions-waiting-on-me`, `summarize-this-submission`, `did-we-lose-this-account` — instead of the API verbs an integration engineer would reach for. The v0.1.0 cut shipped on 2026-05-04 as 30 merged PRs (+14,521 / -819 lines), comprising six foundation packages, five read-only PolicyCenter tools, a Claude Code plugin manifest, and a live architecture diagram on a custom subdomain. Alongside the code, ~30k words of blueprint documents — business case, PRD, architecture, user journey, technical spec, roadmap — landed in `blueprint/` on the same day. (All 30 merged PRs are visible at [github.com/jeremylongshore/guidewire-mcp-for-claude/pulls?q=is%3Apr+is%3Amerged](https://github.com/jeremylongshore/guidewire-mcp-for-claude/pulls?q=is%3Apr+is%3Amerged).)

--- a/marketplace/src/content/blog-posts/guidewire-mcp-v0-1-0-v0-1-1-76-minutes.md
+++ b/marketplace/src/content/blog-posts/guidewire-mcp-v0-1-0-v0-1-1-76-minutes.md
@@ -4,6 +4,7 @@ description: "v0.1.0 shipped at 19:14 Mountain, surfaced an install-path defect 
 date: "2026-05-06"
 tags: ["mcp", "guidewire", "release-engineering", "postgres-audit", "case-study"]
 featured: false
+canonical: "https://startaitools.com/posts/guidewire-mcp-v0-1-0-v0-1-1-76-minutes/"
 ---
 Insurance carriers run on Guidewire InsuranceSuite — PolicyCenter, ClaimCenter, BillingCenter. Underwriters and claims adjusters spend hours navigating the UI to answer questions like *"what submissions are waiting on me?"* or *"why isn't the Acme account active anymore?"*. The Cloud API exists, but it speaks REST verbs (`GET /job/v1/jobs?subtype=Submission&status=Quoted&assignedTo=alice`). LLMs route well on operator language and badly on REST verbs. So the tools are named like the question an operator would actually ask:
 

--- a/marketplace/src/content/blog-posts/hitl-delivery-is-a-fail-closed-exactly-once-problem.md
+++ b/marketplace/src/content/blog-posts/hitl-delivery-is-a-fail-closed-exactly-once-problem.md
@@ -4,6 +4,7 @@ description: "Human-in-the-loop agent delivery is exactly-once, fail-closed. Two
 date: "2026-06-07"
 tags: ["ai-agents", "typescript", "architecture", "slack", "distributed-systems"]
 featured: false
+canonical: "https://startaitools.com/posts/hitl-delivery-is-a-fail-closed-exactly-once-problem/"
 ---
 Two repos. One missing guarantee.
 

--- a/marketplace/src/content/blog-posts/honest-perf-benchmarks-paid-api-compiler.md
+++ b/marketplace/src/content/blog-posts/honest-perf-benchmarks-paid-api-compiler.md
@@ -4,6 +4,7 @@ description: "Four PRs, three releases, and a benchmark suite that won't lie to 
 date: "2026-05-17"
 tags: ["typescript", "testing", "architecture", "ci-cd", "ai-agents"]
 featured: false
+canonical: "https://startaitools.com/posts/honest-perf-benchmarks-paid-api-compiler/"
 ---
 `intentional-cognition-os` is a TypeScript "compiler" — markdown sources go in one end, a structured artifact comes out the other, and several of the middle stages call paid Claude APIs to do the cognitive work. Up to today there were zero performance gates on any of it. No baseline, no regression alarm, no "did that refactor make ingest 4× slower" check.
 

--- a/marketplace/src/content/blog-posts/honor-the-gate-when-the-verdict-is-inconvenient.md
+++ b/marketplace/src/content/blog-posts/honor-the-gate-when-the-verdict-is-inconvenient.md
@@ -4,6 +4,7 @@ description: "A quality gate only matters if you honor its verdict. How pre-regi
 date: "2026-06-10"
 tags: ["testing", "ci-cd", "ml-engineering", "devops"]
 featured: false
+canonical: "https://startaitools.com/posts/honor-the-gate-when-the-verdict-is-inconvenient/"
 ---
 On June 10, 2026, two completely unrelated systems hit quality gates that came back the wrong way. Neither system rationalized the verdict. Both honored it. That honesty is what makes the gate worth having.
 

--- a/marketplace/src/content/blog-posts/how-to-get-adk-agent-into-google-community-showcase.md
+++ b/marketplace/src/content/blog-posts/how-to-get-adk-agent-into-google-community-showcase.md
@@ -4,6 +4,7 @@ description: "A tactical breakdown of contributing to Google's agent-starter-pac
 date: "2025-12-11"
 tags: ["adk", "google-cloud", "vertex-ai", "open-source", "agent-development-kit"]
 featured: false
+canonical: "https://startaitools.com/posts/how-to-get-your-adk-agent-into-googles-official-community-showcase/"
 ---
 # How to Get Your ADK Agent into Google's Official Community Showcase
 

--- a/marketplace/src/content/blog-posts/hybrid-ai-stack-reduce-costs-60-80-percent-intelligent-routing.md
+++ b/marketplace/src/content/blog-posts/hybrid-ai-stack-reduce-costs-60-80-percent-intelligent-routing.md
@@ -4,6 +4,7 @@ description: "Production-ready AI orchestration system that intelligently routes
 date: "2025-10-07"
 tags: ["ai", "cost-optimization", "infrastructure", "cloud-architecture", "llms", "docker", "open-source"]
 featured: false
+canonical: "https://startaitools.com/posts/hybrid-ai-stack-reduce-ai-api-costs-by-60-80-with-intelligent-request-routing/"
 ---
 # Hybrid AI Stack: Reduce AI API Costs by 60-80% with Intelligent Request Routing
 

--- a/marketplace/src/content/blog-posts/idle-state-cleanup-duplicate-rules-playbooks.md
+++ b/marketplace/src/content/blog-posts/idle-state-cleanup-duplicate-rules-playbooks.md
@@ -4,6 +4,7 @@ description: "Maintenance sweep across four repos: braves idle-state trim, claud
 date: "2026-04-22"
 tags: ["typescript", "python", "ci-cd", "claude-code", "devops", "full-stack"]
 featured: false
+canonical: "https://startaitools.com/posts/idle-state-cleanup-duplicate-rules-playbooks/"
 ---
 A maintenance day across four repos — broadcast tooling, policy engine, marketplace, and a renamed agent. Each fix small, together readable in a minute.
 

--- a/marketplace/src/content/blog-posts/intent-solutions-october-2025-state-of-affairs.md
+++ b/marketplace/src/content/blog-posts/intent-solutions-october-2025-state-of-affairs.md
@@ -4,6 +4,7 @@ description: "A candid look at Intent Solutions' current projects: DiagnosticPro
 date: "2025-10-20"
 tags: ["career-growth", "startup", "ai-automation", "retrospective", "portfolio"]
 featured: false
+canonical: "https://startaitools.com/posts/october-2025-state-of-affairs-five-production-platforms-and-what-they-taught-me/"
 ---
 ## The Reality Check
 

--- a/marketplace/src/content/blog-posts/intent-solutions-portfolio-2025-five-production-platforms-and-the-architecture-b.md
+++ b/marketplace/src/content/blog-posts/intent-solutions-portfolio-2025-five-production-platforms-and-the-architecture-b.md
@@ -4,6 +4,7 @@ description: "Intent Solutions Portfolio 2025: Five Production Platforms and the
 date: "2025-10-20"
 tags: ["start-ai-tools"]
 featured: false
+canonical: "https://startaitools.com/posts/intent-solutions-portfolio-2025-five-production-platforms-and-the-architecture-behind-4-day-deployments/"
 ---
 <p>When you see “deploy in days, not months,” it sounds like marketing fluff. This is the technical breakdown of how Intent Solutions actually does it—with five production platforms serving real customers, measurable cost optimization, and architecture patterns you can replicate.</p>
 <h2 id="the-portfolio-five-production-platforms">The Portfolio: Five Production Platforms</h2>

--- a/marketplace/src/content/blog-posts/intent-solutions-portfolio-2025-production-deployment-velocity.md
+++ b/marketplace/src/content/blog-posts/intent-solutions-portfolio-2025-production-deployment-velocity.md
@@ -4,6 +4,7 @@ description: "Deep dive into Intent Solutions' five production platforms: Diagno
 date: "2025-10-20"
 tags: ["portfolio", "architecture", "deployment", "gcp", "ai-automation", "case-study"]
 featured: false
+canonical: "https://startaitools.com/posts/intent-solutions-portfolio-2025-five-production-platforms-and-the-architecture-behind-4-day-deployments/"
 ---
 When you see "deploy in days, not months," it sounds like marketing fluff. This is the technical breakdown of how Intent Solutions actually does it—with five production platforms serving real customers, measurable cost optimization, and architecture patterns you can replicate.
 

--- a/marketplace/src/content/blog-posts/intentcad-v080-thirteen-epics-one-day.md
+++ b/marketplace/src/content/blog-posts/intentcad-v080-thirteen-epics-one-day.md
@@ -4,6 +4,7 @@ description: "Thirteen EPICs shipped in a single day. Drawing intelligence, comp
 date: "2026-03-08"
 tags: ["ai-agents", "architecture", "python", "release-engineering"]
 featured: false
+canonical: "https://startaitools.com/posts/intentcad-v080-thirteen-epics-one-day/"
 ---
 Thirteen EPICs. One day. The largest single-day feature push in [IntentCAD](https://github.com/jeremylongshore/cad-dxf-agent) history, from EPIC-CAD-19 to EPIC-CAD-30.
 

--- a/marketplace/src/content/blog-posts/intentcad-viewer-dwg-fastview-parity.md
+++ b/marketplace/src/content/blog-posts/intentcad-viewer-dwg-fastview-parity.md
@@ -4,6 +4,7 @@ description: "Web workers, animated zoom, progress feedback, and color-coded sel
 date: "2026-03-28"
 tags: ["react", "web-development", "architecture", "testing", "python"]
 featured: false
+canonical: "https://startaitools.com/posts/intentcad-viewer-dwg-fastview-parity/"
 ---
 DWG FastView is the benchmark. It's the viewer AEC professionals already use. It loads fast, zooms smooth, and never locks the UI on a 50MB drawing. If your browser-based CAD viewer doesn't match that bar, nobody will trust it with real work.
 

--- a/marketplace/src/content/blog-posts/irsb-monorepo-v1-extracting-shared-packages.md
+++ b/marketplace/src/content/blog-posts/irsb-monorepo-v1-extracting-shared-packages.md
@@ -4,6 +4,7 @@ description: "How I extracted @irsb/kms-signer and @irsb/types into shared packa
 date: "2026-02-16"
 tags: ["monorepo", "typescript", "blockchain", "npm-packages", "architecture", "ci-cd"]
 featured: false
+canonical: "https://startaitools.com/posts/irsb-monorepo-v1-extracting-shared-packages/"
 ---
 ## Why a Monorepo
 

--- a/marketplace/src/content/blog-posts/knowledge-base-zero-to-api-lifecycle-state-machine.md
+++ b/marketplace/src/content/blog-posts/knowledge-base-zero-to-api-lifecycle-state-machine.md
@@ -4,6 +4,7 @@ description: "Building a team knowledge base with lifecycle state machines, poli
 date: "2026-03-18"
 tags: ["typescript", "architecture", "full-stack", "automation", "monorepo"]
 featured: false
+canonical: "https://startaitools.com/posts/knowledge-base-zero-to-api-lifecycle-state-machine/"
 ---
 Most knowledge bases are wikis with a search box. Articles go in, articles rot, nobody notices. The problem isn't storage. It's governance.
 

--- a/marketplace/src/content/blog-posts/knowledge-os-bootstrap-seven-epics-marketplace-security.md
+++ b/marketplace/src/content/blog-posts/knowledge-os-bootstrap-seven-epics-marketplace-security.md
@@ -4,6 +4,7 @@ description: "Bootstrapping a local-first knowledge OS from standards documents 
 date: "2026-04-06"
 tags: ["ai-agents", "typescript", "architecture", "testing", "monorepo", "claude-code", "release-engineering"]
 featured: false
+canonical: "https://startaitools.com/posts/knowledge-os-bootstrap-seven-epics-marketplace-security/"
 ---
 Seven epics in one repo. Six releases in one day. A TypeScript monorepo that didn't exist 48 hours ago now has a compiler pipeline, FTS5 search, and citation-verified answers. April 6th was the day intentional-cognition-os went from design documents to a working knowledge operating system.
 

--- a/marketplace/src/content/blog-posts/knowledge-os-render-promote-research-command.md
+++ b/marketplace/src/content/blog-posts/knowledge-os-render-promote-research-command.md
@@ -4,6 +4,7 @@ description: "intentional-cognition-os ships Epics 8 and 9 — a Marp slide deck
 date: "2026-04-08"
 tags: ["ai-agents", "typescript", "testing", "architecture", "release-engineering", "automation"]
 featured: false
+canonical: "https://startaitools.com/posts/knowledge-os-render-promote-research-command/"
 ---
 Three days ago ICO was at v0.1.5. Today it's at v0.4.0. Two epics landed, three releases shipped, and the test count nearly tripled.
 

--- a/marketplace/src/content/blog-posts/leading-complex-system-onboarding-documentation-to-infrastructure-access.md
+++ b/marketplace/src/content/blog-posts/leading-complex-system-onboarding-documentation-to-infrastructure-access.md
@@ -4,6 +4,7 @@ description: "How I approached onboarding a Senior Cybersecurity Engineer to a c
 date: "2025-10-01"
 tags: ["technical-leadership", "devops", "team-building", "problem-solving", "cloud-infrastructure"]
 featured: false
+canonical: "https://startaitools.com/posts/leading-complex-system-onboarding-from-documentation-to-infrastructure-access/"
 ---
 When you're responsible for bringing a new senior team member onto a complex platform spanning multiple GCP projects, hundreds of database tables, and interconnected services, the quality of your onboarding process becomes a direct reflection of your technical leadership capabilities.
 

--- a/marketplace/src/content/blog-posts/legal-toolkit-epic-planning-canary-ci-three-projects.md
+++ b/marketplace/src/content/blog-posts/legal-toolkit-epic-planning-canary-ci-three-projects.md
@@ -4,6 +4,7 @@ description: "A 12-skill legal toolkit with 5 parallel agents, a 117-bead execut
 date: "2026-04-05"
 tags: ["ai-agents", "claude-code", "ci-cd", "architecture", "testing", "authentication"]
 featured: false
+canonical: "https://startaitools.com/posts/legal-toolkit-epic-planning-canary-ci-three-projects/"
 ---
 Three projects. Eleven commits. Every one of them is about the same thing: building systems that check their own work.
 

--- a/marketplace/src/content/blog-posts/let-the-model-judge-make-the-code-decide.md
+++ b/marketplace/src/content/blog-posts/let-the-model-judge-make-the-code-decide.md
@@ -4,6 +4,7 @@ description: "A production writing pipeline rebuilt around one rule: the languag
 date: "2026-07-17"
 tags: ["ai-agents", "claude-code", "pipeline", "llm", "architecture", "automation"]
 featured: false
+canonical: "https://startaitools.com/posts/let-the-model-judge-make-the-code-decide/"
 ---
 This post was written by the pipeline it describes. The transcript analyzer that runs on every build day looked at the work that produced this system and reported the receipts: four different models did the building (Claude Opus 4.8, Claude Fable 5, Grok 4.5, and GPT-5.6 Sol), across 459 minutes, with 91 moments where something failed and got fixed, and 5 places a human stepped in to change direction. That is not a brag. It is the point. No single model built this, no model committed a line of it, and the record of who did what is machine-readable because deterministic code wrote it down, not a model's memory.
 

--- a/marketplace/src/content/blog-posts/live-data-backbone-cache-circuits-sse.md
+++ b/marketplace/src/content/blog-posts/live-data-backbone-cache-circuits-sse.md
@@ -4,6 +4,7 @@ description: "Wiring MLB Stats API, GUMBO feeds, and Statcast into a fault-toler
 date: "2026-03-02"
 tags: ["full-stack", "architecture", "typescript", "fastapi", "python", "devops"]
 featured: false
+canonical: "https://startaitools.com/posts/live-data-backbone-cache-circuits-sse/"
 ---
 Yesterday was the scaffold. Today the data actually flows.
 

--- a/marketplace/src/content/blog-posts/liveness-without-health-is-theater.md
+++ b/marketplace/src/content/blog-posts/liveness-without-health-is-theater.md
@@ -4,6 +4,7 @@ description: "A heartbeat that fires on every run proves a job ran, never that i
 date: "2026-07-10"
 tags: ["monitoring", "reliability", "devops", "observability", "cron"]
 featured: false
+canonical: "https://startaitools.com/posts/liveness-without-health-is-theater/"
 ---
 Every team that runs scheduled work eventually ships the same bug, and it does
 not look like a bug. A cron job, a nightly workflow, a backup timer — something

--- a/marketplace/src/content/blog-posts/llm-legible-deterministic-architecture.md
+++ b/marketplace/src/content/blog-posts/llm-legible-deterministic-architecture.md
@@ -4,6 +4,7 @@ description: "You can ship a dozen good mechanisms and still have no architectur
 date: "2026-07-23"
 tags: ["architecture", "ai-agents", "claude-code", "devops"]
 featured: false
+canonical: "https://startaitools.com/posts/llm-legible-deterministic-architecture/"
 ---
 You can accumulate a dozen genuinely good mechanisms and still not have an architecture.
 

--- a/marketplace/src/content/blog-posts/making-fire-and-forget-capture-safe-under-failure.md
+++ b/marketplace/src/content/blog-posts/making-fire-and-forget-capture-safe-under-failure.md
@@ -4,6 +4,7 @@ description: "Five properties an unattended capture hook needs before you turn i
 date: "2026-07-11"
 tags: ["architecture", "idempotency", "ai-agents", "claude-code", "distributed-systems"]
 featured: false
+canonical: "https://startaitools.com/posts/making-fire-and-forget-capture-safe-under-failure/"
 ---
 There is a hook that distills a finished Claude Code session into a few durable learnings and proposes them to a shared team brain. It runs on `SessionEnd`. Nobody watches it. That last sentence is the entire problem.
 

--- a/marketplace/src/content/blog-posts/manifest-system-mutation-testing-pyramid.md
+++ b/marketplace/src/content/blog-posts/manifest-system-mutation-testing-pyramid.md
@@ -4,6 +4,7 @@ description: "Epic 31-B lands the publish side of the bot-manifest protocol in c
 date: "2026-04-20"
 tags: ["typescript", "testing", "ci-cd", "architecture", "monorepo", "claude-code", "release-engineering"]
 featured: false
+canonical: "https://startaitools.com/posts/manifest-system-mutation-testing-pyramid/"
 ---
 You can ship a feature that looks tested and isn't. April 20 was two coordinated answers to that problem.
 

--- a/marketplace/src/content/blog-posts/marketing-automation-project-pricing-exploration.md
+++ b/marketplace/src/content/blog-posts/marketing-automation-project-pricing-exploration.md
@@ -4,6 +4,7 @@ description: "What I'm Discovering About Marketing Automation Pricing Challenges
 date: "2025-09-12"
 tags: ["consulting", "market-research", "marketing-automation", "industry-analysis", "gohighlevel"]
 featured: false
+canonical: "https://startaitools.com/posts/what-im-discovering-about-marketing-automation-pricing-challenges/"
 ---
 # What I'm Discovering About Marketing Automation Pricing Challenges
 

--- a/marketplace/src/content/blog-posts/marketplace-quality-blitz-130-stubs-4300-warnings.md
+++ b/marketplace/src/content/blog-posts/marketplace-quality-blitz-130-stubs-4300-warnings.md
@@ -4,6 +4,7 @@ description: "Replacing 130 empty SKILL.md stubs with real content, fixing 4300+
 date: "2026-03-10"
 tags: ["claude-code", "automation", "ci-cd", "web-development", "ai-agents"]
 featured: false
+canonical: "https://startaitools.com/posts/marketplace-quality-blitz-130-stubs-4300-warnings/"
 ---
 130 plugins had SKILL.md files that said nothing.
 

--- a/marketplace/src/content/blog-posts/master-directory-standards-prompt-repository-organization.md
+++ b/marketplace/src/content/blog-posts/master-directory-standards-prompt-repository-organization.md
@@ -4,6 +4,7 @@ description: "How we systematically applied master directory standards to organi
 date: "2025-10-08"
 tags: ["directory-structure", "organization", "standards", "automation", "taskwarrior", "github-workflows", "qa-testing"]
 featured: false
+canonical: "https://startaitools.com/posts/applying-universal-directory-standards-to-a-prompt-engineering-repository/"
 ---
 ## The Problem: Inconsistent File Naming Across Master Systems
 

--- a/marketplace/src/content/blog-posts/meta-agent-orchestration-and-the-ux-of-removing-features.md
+++ b/marketplace/src/content/blog-posts/meta-agent-orchestration-and-the-ux-of-removing-features.md
@@ -4,6 +4,7 @@ description: "The oss-agent-lab ships its meta-agent capstone — one agent to o
 date: "2026-03-16"
 tags: ["ai-agents", "claude-code", "python", "web-development", "architecture"]
 featured: false
+canonical: "https://startaitools.com/posts/meta-agent-orchestration-and-the-ux-of-removing-features/"
 ---
 Nine specialist agents. One meta-agent to rule them.
 

--- a/marketplace/src/content/blog-posts/mobile-fixes-crypto-upgrades-and-killer-skills.md
+++ b/marketplace/src/content/blog-posts/mobile-fixes-crypto-upgrades-and-killer-skills.md
@@ -4,6 +4,7 @@ description: "Fixing overlapping cards at 480px, upgrading all 25 crypto skills 
 date: "2026-03-11"
 tags: ["web-development", "claude-code", "devops", "firebase"]
 featured: false
+canonical: "https://startaitools.com/posts/mobile-fixes-crypto-upgrades-and-killer-skills/"
 ---
 Your marketplace looks great on a 1440px monitor. Nobody uses a 1440px monitor.
 

--- a/marketplace/src/content/blog-posts/n8n-service-layer-scrub-vendor-removal.md
+++ b/marketplace/src/content/blog-posts/n8n-service-layer-scrub-vendor-removal.md
@@ -4,6 +4,7 @@ description: "Vendor removal isn't one edit. It's a service-layer scrub across h
 date: "2026-04-26"
 tags: ["web-development", "devops", "claude-code", "automation"]
 featured: false
+canonical: "https://startaitools.com/posts/n8n-service-layer-scrub-vendor-removal/"
 ---
 Removing a vendor from your positioning isn't a single find-and-replace. It's a service-layer scrub: hunt every passive mention, rewrite the comparison surface, fix every internal link, and ship it all in one coherent commit so the story stays intact.
 

--- a/marketplace/src/content/blog-posts/n8n-workflow-automation-enterprise-guide.md
+++ b/marketplace/src/content/blog-posts/n8n-workflow-automation-enterprise-guide.md
@@ -4,6 +4,7 @@ description: "Complete guide to N8N workflow automation for enterprises - from b
 date: "2025-09-08"
 tags: ["n8n", "automation", "no-code", "workflow", "business-process", "productivity", "integration"]
 featured: false
+canonical: "https://startaitools.com/posts/n8n-workflow-automation-building-enterprise-automation-without-code/"
 ---
 ## Executive Summary
 

--- a/marketplace/src/content/blog-posts/ninety-skills-three-packs-one-day.md
+++ b/marketplace/src/content/blog-posts/ninety-skills-three-packs-one-day.md
@@ -4,6 +4,7 @@ description: "Building three complete 30-skill SaaS integration packs — Sentry
 date: "2026-03-22"
 tags: ["claude-code", "automation", "architecture", "release-engineering", "ai-agents"]
 featured: false
+canonical: "https://startaitools.com/posts/ninety-skills-three-packs-one-day/"
 ---
 One hundred commits. Three complete SaaS packs. Ninety skills from zero to shipped.
 

--- a/marketplace/src/content/blog-posts/noise-robust-signed-llm-judge-evals.md
+++ b/marketplace/src/content/blog-posts/noise-robust-signed-llm-judge-evals.md
@@ -4,6 +4,7 @@ description: "An un-seeded LLM judge is a coin flip even at temperature 0. How w
 date: "2026-07-07"
 tags: ["ai-agents", "evals", "llm-as-judge", "testing", "provenance", "ci-cd"]
 featured: false
+canonical: "https://startaitools.com/posts/noise-robust-signed-llm-judge-evals/"
 ---
 An un-seeded LLM judge is nondeterministic even at temperature 0. So a single-call binary verdict is a coin flip. And when you sign that verdict into a public transparency log, you have cryptographically attested one noisy draw as if it were ground truth.
 

--- a/marketplace/src/content/blog-posts/now-lms-2-0-and-the-email-cutover.md
+++ b/marketplace/src/content/blog-posts/now-lms-2-0-and-the-email-cutover.md
@@ -4,6 +4,7 @@ description: "A 2.0.0 that is mostly a careful rename plus security headers is e
 date: "2026-07-25"
 tags: ["release-engineering", "python", "devops", "web-development"]
 featured: false
+canonical: "https://startaitools.com/posts/now-lms-2-0-and-the-email-cutover/"
 ---
 A healthy major version is not always a rewrite. now-lms shipped 2.0.0 yesterday as proof: the release was ninety percent discipline, ten percent new surface area. The breaking changes were documented with exact incompatibility points. A migration guide shipped alongside the code. That is the standard.
 

--- a/marketplace/src/content/blog-posts/nuclear-option-day-validator-rewrite-414-plugins.md
+++ b/marketplace/src/content/blog-posts/nuclear-option-day-validator-rewrite-414-plugins.md
@@ -4,6 +4,7 @@ description: "Rewrote the universal validator from scratch to match Anthropic's 
 date: "2026-03-21"
 tags: ["claude-code", "architecture", "automation", "release-engineering", "ai-agents", "typescript"]
 featured: false
+canonical: "https://startaitools.com/posts/nuclear-option-day-validator-rewrite-414-plugins/"
 ---
 Some days you file tickets. Some days you refactor a module. March 21st was not one of those days.
 

--- a/marketplace/src/content/blog-posts/oklch-color-system-marketplace-facelift.md
+++ b/marketplace/src/content/blog-posts/oklch-color-system-marketplace-facelift.md
@@ -4,6 +4,7 @@ description: "HSL colors look mathematically equal but perceptually wrong. OKLCH
 date: "2026-03-13"
 tags: ["web-development", "architecture", "css"]
 featured: false
+canonical: "https://startaitools.com/posts/oklch-color-system-marketplace-facelift/"
 ---
 Pick two colors in HSL. Same saturation, same lightness, different hues. They should look equally bright. They don't.
 

--- a/marketplace/src/content/blog-posts/oss-agent-lab-meta-agent-system-one-day.md
+++ b/marketplace/src/content/blog-posts/oss-agent-lab-meta-agent-system-one-day.md
@@ -4,6 +4,7 @@ description: "From first commit to a 9-specialist multi-agent system with capabi
 date: "2026-03-15"
 tags: ["ai-agents", "python", "architecture", "testing", "automation"]
 featured: false
+canonical: "https://startaitools.com/posts/oss-agent-lab-meta-agent-system-one-day/"
 ---
 What if the agent routing your requests was itself an agent? Not a switch statement with an LLM wrapper. An actual agent that evaluates other agents, scores their capabilities, remembers what worked, and routes based on evidence.
 

--- a/marketplace/src/content/blog-posts/passing-is-not-validating.md
+++ b/marketplace/src/content/blog-posts/passing-is-not-validating.md
@@ -4,6 +4,7 @@ description: "A JSON Schema validator passed all 19 checks while validating noth
 date: "2026-07-19"
 tags: ["testing", "python", "ci-cd", "architecture", "debugging"]
 featured: false
+canonical: "https://startaitools.com/posts/passing-is-not-validating/"
 ---
 A validator gate returned green on every check. Nineteen rule checks across four rules, all passing. And most of them were exercising nothing at all.
 

--- a/marketplace/src/content/blog-posts/pdf-extraction-sweep-day-42-commits.md
+++ b/marketplace/src/content/blog-posts/pdf-extraction-sweep-day-42-commits.md
@@ -4,6 +4,7 @@ description: "Sub-pixel noise, color inheritance, and coordinate conventions. Fi
 date: "2026-03-05"
 tags: ["python", "debugging", "architecture", "full-stack", "release-engineering", "cad"]
 featured: false
+canonical: "https://startaitools.com/posts/pdf-extraction-sweep-day-42-commits/"
 ---
 Forty-two commits across six repos in one day. No new features. Just closing loops, killing bugs, and hardening things that almost worked.
 

--- a/marketplace/src/content/blog-posts/perception-dashboard-real-triggers-topic-watchlists.md
+++ b/marketplace/src/content/blog-posts/perception-dashboard-real-triggers-topic-watchlists.md
@@ -4,6 +4,7 @@ description: "How Perception moved from mock ingestion to real Firestore trigger
 date: "2026-02-10"
 tags: ["firebase", "firestore", "mcp", "dashboard", "licensing", "full-stack"]
 featured: false
+canonical: "https://startaitools.com/posts/perception-dashboard-real-triggers-topic-watchlists/"
 ---
 ## What Perception Does
 

--- a/marketplace/src/content/blog-posts/plugin-scripts-lint-gap-shellcheck-ruff.md
+++ b/marketplace/src/content/blog-posts/plugin-scripts-lint-gap-shellcheck-ruff.md
@@ -4,6 +4,7 @@ description: "Plugin scripts had zero lint coverage. Added shellcheck + ruff to 
 date: "2026-05-26"
 tags: ["ci-cd", "shellcheck", "ruff", "testing", "static-analysis"]
 featured: false
+canonical: "https://startaitools.com/posts/plugin-scripts-lint-gap-shellcheck-ruff/"
 ---
 The CI matrix ran lint-staged and the main workflow against TS/JS/JSON/MD/YAML. Good coverage there. But `plugin/skills/**/*.{sh,py}` — the shell and Python scripts inside plugin archetypes and skill scaffolding — got behavior tests (`test_run_sh.sh`, `test_verify.py`, `test_bank.py`) but nothing ran shellcheck or ruff on them. A quoting bug, an unused import, or a quote-injection footgun could land without signal.
 

--- a/marketplace/src/content/blog-posts/postgres-approval-sink-bugs-the-tests-caught.md
+++ b/marketplace/src/content/blog-posts/postgres-approval-sink-bugs-the-tests-caught.md
@@ -4,6 +4,7 @@ description: "A no-mocks testcontainers policy caught two production-fatal Postg
 date: "2026-05-05"
 tags: ["postgres", "testing", "testcontainers", "architecture", "ci-cd", "authentication", "typescript"]
 featured: false
+canonical: "https://startaitools.com/posts/postgres-approval-sink-bugs-the-tests-caught/"
 ---
 ## Thesis
 

--- a/marketplace/src/content/blog-posts/pregame-storylines-infinite-loading-fix.md
+++ b/marketplace/src/content/blog-posts/pregame-storylines-infinite-loading-fix.md
@@ -4,6 +4,7 @@ description: "The pregame view showed 'Generating storylines...' forever when th
 date: "2026-04-10"
 tags: ["debugging", "typescript", "full-stack", "python"]
 featured: false
+canonical: "https://startaitools.com/posts/pregame-storylines-infinite-loading-fix/"
 ---
 The Braves Booth pregame view had a spinner that never stopped spinning.
 

--- a/marketplace/src/content/blog-posts/producer-fallback-when-claude-hits-weekly-limit.md
+++ b/marketplace/src/content/blog-posts/producer-fallback-when-claude-hits-weekly-limit.md
@@ -4,6 +4,7 @@ description: "A weekly LLM limit is a producer outage, not a reason to miss the 
 date: "2026-07-15"
 tags: ["automation", "devops", "claude-code", "blogging", "reliability"]
 featured: false
+canonical: "https://startaitools.com/posts/producer-fallback-when-claude-hits-weekly-limit/"
 ---
 A daily content pipeline that dies because one model returns a rate-limit error is measuring the wrong success criterion. The job is not "Claude ran." The job is "yesterday has a post on the live site."
 

--- a/marketplace/src/content/blog-posts/prompts-intent-solutions-repository-transformation-guide.md
+++ b/marketplace/src/content/blog-posts/prompts-intent-solutions-repository-transformation-guide.md
@@ -4,6 +4,7 @@ description: "Complete transformation guide: How we turned a cluttered prompt co
 date: "2025-10-02"
 tags: ["repository-management", "prompt-engineering", "github-pages", "automation", "ai-development", "claude-code"]
 featured: false
+canonical: "https://startaitools.com/posts/repository-transformation-from-chaos-to-professional-prompt-engineering-toolkit/"
 ---
 ## Executive Summary
 

--- a/marketplace/src/content/blog-posts/propagation-day-when-the-spec-becomes-the-migration-plan.md
+++ b/marketplace/src/content/blog-posts/propagation-day-when-the-spec-becomes-the-migration-plan.md
@@ -4,6 +4,7 @@ description: "Three CLAUDE.md spec entries hit critical mass on the same day acr
 date: "2026-04-30"
 tags: ["claudecode", "engineering-management", "secrets", "testing", "infrastructure"]
 featured: false
+canonical: "https://startaitools.com/posts/propagation-day-when-the-spec-becomes-the-migration-plan/"
 ---
 On April 30, three patterns that had been written into `~/.claude/CLAUDE.md` weeks or months earlier as "TO-DO: propagate to all repos, then delete this section" all reached critical mass on the same day. The bd-sync three-layer mirror got its first real-world execution against 24 beads at the Braves Booth repo. The SOPS+age secrets standard flipped on in six repos via one idempotent helper script. The marketplace `compatible-with` → `compatibility` rename swept across 2,849 skills in one batch run. The numbers add up to the kind of graph that looks impressive in a screenshot — 3,000+ files changed, 45 PRs merged, 9 repos touched.
 

--- a/marketplace/src/content/blog-posts/python-class-identity-mismatch-ci-debugging-guide.md
+++ b/marketplace/src/content/blog-posts/python-class-identity-mismatch-ci-debugging-guide.md
@@ -4,6 +4,7 @@ description: "How a subtle Python import path difference caused isinstance() to 
 date: "2025-12-12"
 tags: ["python", "ci-cd", "debugging", "testing", "devops", "adk", "google-cloud"]
 featured: false
+canonical: "https://startaitools.com/posts/python-class-identity-mismatch-the-ci-bug-that-broke-9-prs/"
 ---
 ## The Problem: CI Failing Everywhere
 

--- a/marketplace/src/content/blog-posts/qcss-research-corpus-twenty-one-documents.md
+++ b/marketplace/src/content/blog-posts/qcss-research-corpus-twenty-one-documents.md
@@ -4,6 +4,7 @@ description: "4000+ lines across 21 documents — invention disclosure, 6-paper 
 date: "2026-04-13"
 tags: ["architecture", "ai-engineering", "claude-code", "automation"]
 featured: false
+canonical: "https://startaitools.com/posts/qcss-research-corpus-twenty-one-documents/"
 ---
 Every vector search system you have ever used assumes the same thing: that someone already ran every document through an embedding model and stored the results. For most workloads, that assumption is fine. For some, it is fatal.
 

--- a/marketplace/src/content/blog-posts/react-native-mobile-app-one-session.md
+++ b/marketplace/src/content/blog-posts/react-native-mobile-app-one-session.md
@@ -4,6 +4,7 @@ description: "How I built a complete React Native mobile app with Firebase auth,
 date: "2025-12-13"
 tags: ["react-native", "expo", "firebase", "mobile-development", "typescript", "architecture"]
 featured: false
+canonical: "https://startaitools.com/posts/building-a-complete-react-native-mobile-app-in-one-session-17620-lines-of-production-code/"
 ---
 ## The Challenge
 

--- a/marketplace/src/content/blog-posts/readiness-audit-before-the-dns-flip.md
+++ b/marketplace/src/content/blog-posts/readiness-audit-before-the-dns-flip.md
@@ -4,6 +4,7 @@ description: "An adversarial readiness audit found a payment-path bug that would
 date: "2026-07-01"
 tags: ["migration", "self-hosting", "devops", "testing", "stripe", "vps"]
 featured: false
+canonical: "https://startaitools.com/posts/readiness-audit-before-the-dns-flip/"
 ---
 ## The cutover that would have taken the money and then broken
 

--- a/marketplace/src/content/blog-posts/relevance-score-broke-cite-or-refuse-gate.md
+++ b/marketplace/src/content/blog-posts/relevance-score-broke-cite-or-refuse-gate.md
@@ -4,6 +4,7 @@ description: "A retrieval test asserted every relevance score sits in [0,1] — 
 date: "2026-07-05"
 tags: ["testing", "python", "rag", "debugging", "ci-cd"]
 featured: false
+canonical: "https://startaitools.com/posts/relevance-score-broke-cite-or-refuse-gate/"
 ---
 A test you write to satisfy an audit can catch a correctness bug that has been silently shipping in production. That's what happened in our local RAG system: a vector-retrieval assertion failed on a live relevance score of -1.83 — and that out-of-range score was silently corrupting the exact cite-or-refuse safety gate the system was built to defend.
 

--- a/marketplace/src/content/blog-posts/repo-resolver-integration-typed-errors-monorepo-detection.md
+++ b/marketplace/src/content/blog-posts/repo-resolver-integration-typed-errors-monorepo-detection.md
@@ -4,6 +4,7 @@ description: "A shared repo-resolver package shipped into claude-runtime — ADR
 date: "2026-04-14"
 tags: ["typescript", "architecture", "monorepo", "claude-code", "ai-agents", "automation"]
 featured: false
+canonical: "https://startaitools.com/posts/repo-resolver-integration-typed-errors-monorepo-detection/"
 ---
 Three different services in the qmd-team-intent-kb stack all need to answer the same question: "what repo is this?" The edge-daemon needs it at spool time to tag captured memory candidates. The MCP server needs it at query time to scope retrieval. The ingestion pipeline needs it at index time to build canonical tenant partitions. Before April 14, each of them had its own half-answer — `resolveGitContext()` variants with different edge-case handling, different caching strategies, and a long tail of bugs around SSH vs HTTPS remotes and monorepo roots.
 

--- a/marketplace/src/content/blog-posts/research-curriculum.md
+++ b/marketplace/src/content/blog-posts/research-curriculum.md
@@ -4,6 +4,7 @@ description: "Research & Curriculum"
 date: "2001-01-01"
 tags: ["start-ai-tools"]
 featured: false
+canonical: "https://startaitools.com/posts/research-curriculum/"
 ---
 <h2 id="ai-engineering-curriculum--technical-papers">AI Engineering Curriculum &amp; Technical Papers</h2>
 <p>Welcome to our research collection featuring academic papers, technical studies, and in-depth analysis in AI development and systems architecture.</p>

--- a/marketplace/src/content/blog-posts/resizable-columns-wcag-contrast-braves-dashboard.md
+++ b/marketplace/src/content/blog-posts/resizable-columns-wcag-contrast-braves-dashboard.md
@@ -4,6 +4,7 @@ description: "Adding drag-to-resize panels and fixing WCAG AA contrast ratios on
 date: "2026-04-07"
 tags: ["react", "full-stack", "web-development", "architecture"]
 featured: false
+canonical: "https://startaitools.com/posts/resizable-columns-wcag-contrast-braves-dashboard/"
 ---
 Light day. Two PRs merged on Braves Booth Intelligence, both polish work. No new features, no new endpoints. Just making the existing dashboard better for the people who actually use it during live broadcasts.
 

--- a/marketplace/src/content/blog-posts/scaling-ai-batch-processing-enhancing-235-plugins-with-vertex-ai-gemini-on-the-free-tier.md
+++ b/marketplace/src/content/blog-posts/scaling-ai-batch-processing-enhancing-235-plugins-with-vertex-ai-gemini-on-the-free-tier.md
@@ -4,6 +4,7 @@ description: "Building an overnight batch processing system to enhance 235 Claud
 date: "2025-10-19"
 tags: ["vertex-ai", "gemini", "batch-processing", "automation", "rate-limiting", "claude-code", "disaster-recovery", "turso"]
 featured: false
+canonical: "https://startaitools.com/posts/scaling-ai-batch-processing-enhancing-235-plugins-with-vertex-ai-gemini-on-the-free-tier/"
 ---
 ## The Problem: 235 Plugins Need Comprehensive Documentation
 

--- a/marketplace/src/content/blog-posts/scaling-ai-systems-disaster-recovery-production-batch-processing.md
+++ b/marketplace/src/content/blog-posts/scaling-ai-systems-disaster-recovery-production-batch-processing.md
@@ -4,6 +4,7 @@ description: "Scaling AI Systems: Production Batch Processing with Built-In Disa
 date: "2025-10-19"
 tags: ["systems-architecture", "ai-engineering", "disaster-recovery", "automation", "production-systems"]
 featured: false
+canonical: "https://startaitools.com/posts/scaling-ai-systems-production-batch-processing-with-built-in-disaster-recovery/"
 ---
 ## The Challenge: Scale AI Documentation Across 235 Production Systems
 

--- a/marketplace/src/content/blog-posts/schema-debacle-rubric-on-spec-postmortem.md
+++ b/marketplace/src/content/blog-posts/schema-debacle-rubric-on-spec-postmortem.md
@@ -4,6 +4,7 @@ description: "Postmortem on a schema validator debacle: when a stricter enterpri
 date: "2026-04-28"
 tags: ["architecture", "claude-code", "release-engineering", "devops", "schema-design"]
 featured: false
+canonical: "https://startaitools.com/posts/schema-debacle-rubric-on-spec-postmortem/"
 ---
 When you author a stricter enterprise rubric on top of a permissive open spec, the rubric must sit additive on top of the spec — not replace its required-field set with the spec's floor. Demoting required-field errors to warnings to "realign with the underlying spec" breaks the marketplace gate it was built to enforce.
 

--- a/marketplace/src/content/blog-posts/security-audit-nightmare-python-environment-victory-waygate-mcp.md
+++ b/marketplace/src/content/blog-posts/security-audit-nightmare-python-environment-victory-waygate-mcp.md
@@ -4,6 +4,7 @@ description: "A honest look at what happens when a 'quick security audit' turns 
 date: "2025-09-28"
 tags: ["development", "python", "security", "infrastructure", "debugging", "personal-growth", "problem-solving"]
 featured: false
+canonical: "https://startaitools.com/posts/when-a-simple-security-audit-turns-into-a-3-hour-python-environment-battle-and-how-we-won/"
 ---
 Ever have one of those days where you start with a simple task and end up questioning your entire technical setup? That was my Saturday morning when what should have been a "quick security audit" turned into a full-scale infrastructure overhaul.
 

--- a/marketplace/src/content/blog-posts/self-expiring-report-only-ci-gates.md
+++ b/marketplace/src/content/blog-posts/self-expiring-report-only-ci-gates.md
@@ -4,6 +4,7 @@ description: "How a meta-gate enforces deadline-driven CI hardening without free
 date: "2026-05-23"
 tags: ["ci", "devops", "github-actions", "linting", "code-quality"]
 featured: false
+canonical: "https://startaitools.com/posts/self-expiring-report-only-ci-gates/"
 ---
 Advisory CI gates are where good intentions go to die. A team adds a linter "in warning mode for now," and "for now" becomes forever. The violations scroll past in PR reviews, nobody cleans them, the gate never goes blocking. Six months later the warnings are archaeological noise.
 

--- a/marketplace/src/content/blog-posts/server-ops-mcp-safety-before-tools.md
+++ b/marketplace/src/content/blog-posts/server-ops-mcp-safety-before-tools.md
@@ -4,6 +4,7 @@ description: "Design a 7-point safety model before writing tools. How server-ops
 date: "2026-05-22"
 tags: ["mcp", "typescript", "claude-code", "devops", "architecture", "ssh", "automation"]
 featured: false
+canonical: "https://startaitools.com/posts/server-ops-mcp-safety-before-tools/"
 ---
 The Intent Solutions production stack now lives on a single Contabo VPS after [a multi-week migration](/blog/propagation-day-when-the-spec-becomes-the-migration-plan/). Twenty-four containers across five stacks — Braves, Plane, Twenty, Umami, ntfy — sit behind one Caddy reverse proxy. Every day-to-day operational task touches that box: reload Caddy after a host-block edit, restart a stuck container, pull the last 200 lines of a service log, snapshot an instance before a risky change. Doing those by hand from a shell defeats the point of having Claude Code in the loop. Doing them through [a sloppy MCP server](/blog/guidewire-mcp-v0-1-0-foundation-ship/) is how you brick prod from a chat window.
 

--- a/marketplace/src/content/blog-posts/session-cookies-forgot-password-flaky-e2e-tests.md
+++ b/marketplace/src/content/blog-posts/session-cookies-forgot-password-flaky-e2e-tests.md
@@ -4,6 +4,7 @@ description: "Why session cookies beat raw ID tokens, how dynamic imports caused
 date: "2026-02-17"
 tags: ["firebase", "authentication", "e2e-testing", "debugging", "session-management"]
 featured: false
+canonical: "https://startaitools.com/posts/session-cookies-forgot-password-flaky-e2e-tests/"
 ---
 ## The Auth Stack Was Wrong
 

--- a/marketplace/src/content/blog-posts/silent-killer-bare-catch-blocks-hide-failures.md
+++ b/marketplace/src/content/blog-posts/silent-killer-bare-catch-blocks-hide-failures.md
@@ -4,6 +4,7 @@ description: "A real-world case study from a live AI-powered CAD DXF editor: how
 date: "2026-02-25"
 tags: ["debugging", "javascript", "python", "fastapi", "react", "web-development", "cad", "ai", "error-handling"]
 featured: false
+canonical: "https://startaitools.com/posts/silent-killer-bare-catch-blocks-hide-failures/"
 ---
 There's a category of bug that I find genuinely maddening: the kind where the system *works* — no exceptions thrown, no 500 errors logged, CI is green — but the user never sees the output they're supposed to see.
 

--- a/marketplace/src/content/blog-posts/spec-graduation-engagement-architecture-inversion.md
+++ b/marketplace/src/content/blog-posts/spec-graduation-engagement-architecture-inversion.md
@@ -4,6 +4,7 @@ description: "A partner check-in forced a contract re-read, which clarified a co
 date: "2026-05-09"
 tags: ["methodology", "consulting", "partner-engagement", "spec", "mcp", "observability", "architecture"]
 featured: false
+canonical: "https://startaitools.com/posts/spec-graduation-engagement-architecture-inversion/"
 ---
 The cleanest architectural moves of the last six months didn't come from a whiteboard. They came from a partner email that essentially said: hey, remember what we actually signed.
 

--- a/marketplace/src/content/blog-posts/splitting-privileges-at-the-ci-boundary.md
+++ b/marketplace/src/content/blog-posts/splitting-privileges-at-the-ci-boundary.md
@@ -4,6 +4,7 @@ description: "Fork CI privilege separation in GitHub Actions prevents secret exf
 date: "2026-07-24"
 tags: ["ci-cd", "devops", "automation", "claude-code"]
 featured: false
+canonical: "https://startaitools.com/posts/splitting-privileges-at-the-ci-boundary/"
 ---
 ## The Fork Privilege Split
 

--- a/marketplace/src/content/blog-posts/sse-cloud-run-every-platform-lie.md
+++ b/marketplace/src/content/blog-posts/sse-cloud-run-every-platform-lie.md
@@ -4,6 +4,7 @@ description: "SSE looks simple until you deploy it. Firebase Hosting buffers str
 date: "2026-03-04"
 tags: ["debugging", "devops", "full-stack", "typescript", "architecture", "cloud"]
 featured: false
+canonical: "https://startaitools.com/posts/sse-cloud-run-every-platform-lie/"
 ---
 Server-Sent Events are the simplest real-time protocol on the web. One HTTP connection. Text frames. No WebSocket handshake. Every tutorial makes it look trivial.
 

--- a/marketplace/src/content/blog-posts/start-ai-tools-showcase.md
+++ b/marketplace/src/content/blog-posts/start-ai-tools-showcase.md
@@ -4,6 +4,7 @@ description: "Showcasing Start AI Tools - a comprehensive platform for rapid AI 
 date: "2025-09-08"
 tags: ["portfolio", "ai", "platform", "hugo", "tailwind", "netlify", "rapid-deployment"]
 featured: false
+canonical: "https://startaitools.com/posts/start-ai-tools-rapid-ai-implementation-platform/"
 ---
 ## Executive Summary
 

--- a/marketplace/src/content/blog-posts/stop-crying-wolf-3-strike-uptime-monitor-gate.md
+++ b/marketplace/src/content/blog-posts/stop-crying-wolf-3-strike-uptime-monitor-gate.md
@@ -4,6 +4,7 @@ description: "Fix uptime monitor alert fatigue with a 3-strike debounce gate and
 date: "2026-06-08"
 tags: ["devops", "monitoring", "ops", "automation"]
 featured: false
+canonical: "https://startaitools.com/posts/stop-crying-wolf-3-strike-uptime-monitor-gate/"
 ---
 The uptime monitor for scorecardecho.com had been screaming since April 30th. **101 state-changes logged. Roughly 70% of them were sub-60-second flaps** — transients that a single TCP probe shouldn't page the on-call for. The on-call had learned to swipe the alert away.
 

--- a/marketplace/src/content/blog-posts/temporary-is-not-a-plan.md
+++ b/marketplace/src/content/blog-posts/temporary-is-not-a-plan.md
@@ -4,6 +4,7 @@ description: "Adopting an open source LMS got us live in days. What keeps a fork
 date: "2026-07-21"
 tags: ["architecture", "devops", "docker", "open-source", "debugging"]
 featured: false
+canonical: "https://startaitools.com/posts/temporary-is-not-a-plan/"
 ---
 Calling a patch temporary is not a plan. A retirement condition written into the commit is.
 

--- a/marketplace/src/content/blog-posts/terminal-bold-redesign-and-eval-recall-fix.md
+++ b/marketplace/src/content/blog-posts/terminal-bold-redesign-and-eval-recall-fix.md
@@ -4,6 +4,7 @@ description: "Phase 2 of the marketplace facelift brings monospace headings and 
 date: "2026-03-14"
 tags: ["web-development", "claude-code", "testing", "css"]
 featured: false
+canonical: "https://startaitools.com/posts/terminal-bold-redesign-and-eval-recall-fix/"
 ---
 Yesterday was OKLCH. Today is what you do with it.
 

--- a/marketplace/src/content/blog-posts/terraform-complete-learning-guide-infrastructure-as-code.md
+++ b/marketplace/src/content/blog-posts/terraform-complete-learning-guide-infrastructure-as-code.md
@@ -4,6 +4,7 @@ description: "Comprehensive Terraform learning resource covering core concepts, 
 date: "2025-10-07"
 tags: ["terraform", "infrastructure-as-code", "devops", "cloud", "gcp", "aws", "azure"]
 featured: false
+canonical: "https://startaitools.com/posts/terraform-for-ai-infrastructure-complete-learning-guide-from-zero-to-production/"
 ---
 # Terraform for AI Infrastructure: Complete Learning Guide
 

--- a/marketplace/src/content/blog-posts/the-api-is-the-real-boundary.md
+++ b/marketplace/src/content/blog-posts/the-api-is-the-real-boundary.md
@@ -4,6 +4,7 @@ description: "Per-user tokens, a server-side write gate, and a separate access l
 date: "2026-06-13"
 tags: ["authentication", "ai-agents", "architecture", "typescript", "claude-code"]
 featured: false
+canonical: "https://startaitools.com/posts/the-api-is-the-real-boundary/"
 ---
 A single shared API key is fine right up until a second person uses it.
 

--- a/marketplace/src/content/blog-posts/the-automation-that-stopped-publishing-itself.md
+++ b/marketplace/src/content/blog-posts/the-automation-that-stopped-publishing-itself.md
@@ -4,6 +4,7 @@ description: "A 9-day publishing blackout went unnoticed because monitoring repo
 date: "2026-06-06"
 tags: ["automation", "cron", "debugging", "ci-cd", "devops", "monitoring"]
 featured: false
+canonical: "https://startaitools.com/posts/the-automation-that-stopped-publishing-itself/"
 ---
 The blog you're reading publishes itself. Every morning at 7am, a local cron runs `claude -p /blog-backfill` on yesterday's work, classifies it into a content tier, writes the post, runs quality gates, and pushes to live. Monthly retrospectives and calibration reports run on the 1st. On 2026-06-06, the owner noticed posts missing from both startaitools.com and the syndicated copy on tonsofskills.com and asked: "why is the cross-posting not working?"
 

--- a/marketplace/src/content/blog-posts/the-kernel-must-not-import-its-agents.md
+++ b/marketplace/src/content/blog-posts/the-kernel-must-not-import-its-agents.md
@@ -4,6 +4,7 @@ description: "We extracted a stateful watcher agent from a governance kernel and
 date: "2026-07-12"
 tags: ["architecture", "agents", "dependency-management", "governance", "refactoring"]
 featured: false
+canonical: "https://startaitools.com/posts/the-kernel-must-not-import-its-agents/"
 ---
 There is a moment in the life of every framework where an application-shaped thing has grown up inside it. It started as a demo, a reference implementation, a "let's just prove the primitives work" spike. Then it kept running. Now it has cron entries, an operator surface, a test pack, and traceability rows — and it lives in the same repository as the primitives it was only ever meant to exercise.
 

--- a/marketplace/src/content/blog-posts/the-moat-is-the-trust-layer-nexus-byok-rag.md
+++ b/marketplace/src/content/blog-posts/the-moat-is-the-trust-layer-nexus-byok-rag.md
@@ -4,6 +4,7 @@ description: "Naive local-RAG app became Intent NEXUS: BYOK document-intelligenc
 date: "2026-07-04"
 tags: ["ai-agents", "rag", "python", "security", "architecture", "evals"]
 featured: false
+canonical: "https://startaitools.com/posts/the-moat-is-the-trust-layer-nexus-byok-rag/"
 ---
 The moat of a local-RAG tool is not the chatbot. Anyone can wire Ollama to Chroma and put a Streamlit box on top; there are a hundred "local RAG in 100 lines" tutorials that do exactly that. The moat is the *trust layer* underneath the chat: enforced egress control, code-enforced citations, a tamper-evident audit chain, injection defense, and a self-run eval harness that can actually go red. Those are the things a person has to believe before they hand a tool their private documents.
 

--- a/marketplace/src/content/blog-posts/the-wrong-product-built-perfectly.md
+++ b/marketplace/src/content/blog-posts/the-wrong-product-built-perfectly.md
@@ -4,6 +4,7 @@ description: "A new site was scaffolded, deployed, and live with valid TLS in un
 date: "2026-06-05"
 tags: ["architecture", "devops", "claude-code", "hugo", "deployment"]
 featured: false
+canonical: "https://startaitools.com/posts/the-wrong-product-built-perfectly/"
 ---
 A clean pipeline faithfully amplifies a requirements-level error all the way to production. Nothing in a good build process catches a misread spec. The process makes the misread arrive faster, signed, and TLS-valid.
 

--- a/marketplace/src/content/blog-posts/three-parallel-threads-ground-truth-checks.md
+++ b/marketplace/src/content/blog-posts/three-parallel-threads-ground-truth-checks.md
@@ -4,6 +4,7 @@ description: "Three projects, one principle: stop and verify the ground truth be
 date: "2026-04-25"
 tags: ["claude-code", "testing", "ci-cd", "automation"]
 featured: false
+canonical: "https://startaitools.com/posts/three-parallel-threads-ground-truth-checks/"
 ---
 Friday stacked three parallel threads across the Braves Booth, CAD agent, and Intent Solutions landing site — three different codebases, three different problems. They had nothing in common except one operating principle that caught them all: ground truth checks before committing.
 

--- a/marketplace/src/content/blog-posts/three-projects-two-reverts-one-day.md
+++ b/marketplace/src/content/blog-posts/three-projects-two-reverts-one-day.md
@@ -4,6 +4,7 @@ description: "A domain migration saga with two reverts, a broadcast dashboard hi
 date: "2026-03-03"
 tags: ["devops", "web-development", "ci-cd", "full-stack", "firebase"]
 featured: false
+canonical: "https://startaitools.com/posts/three-projects-two-reverts-one-day/"
 ---
 Nothing teaches you Firebase Hosting like renaming your domain three times before lunch.
 

--- a/marketplace/src/content/blog-posts/transitive-cve-clearance-dual-layer-pattern.md
+++ b/marketplace/src/content/blog-posts/transitive-cve-clearance-dual-layer-pattern.md
@@ -4,6 +4,7 @@ description: "How v0.9.1 cleared 6 high-severity transitive CVEs in axios + fast
 date: "2026-05-13"
 tags: ["security", "node", "dependency-management", "bun", "claude-code-slack-channel", "release-engineering"]
 featured: false
+canonical: "https://startaitools.com/posts/transitive-cve-clearance-dual-layer-pattern/"
 ---
 
 You bump a direct dependency to pull in a patched transitive. `bun audit` goes green. The lockfile is committed. Two weeks later, someone does a clean install on a fresh machine, and the vulnerable transitive comes back. This is the transitive CVE trap, and it catches teams with the first move alone.

--- a/marketplace/src/content/blog-posts/twelve-prs-security-sprint-pregame-overhaul.md
+++ b/marketplace/src/content/blog-posts/twelve-prs-security-sprint-pregame-overhaul.md
@@ -4,6 +4,7 @@ description: "Shipping 12 PRs in the Braves broadcast dashboard (strike zone cha
 date: "2026-04-11"
 tags: ["typescript", "react", "full-stack", "claude-code", "debugging", "automation", "ai-agents"]
 featured: false
+canonical: "https://startaitools.com/posts/twelve-prs-security-sprint-pregame-overhaul/"
 ---
 The Braves pregame view was a skeleton. Team names, probable pitchers, a few bullet points from a language model that silently failed half the time. Announcers had to Alt-Tab to MLB.com for anything useful. Meanwhile, a security researcher opened a PR on claude-code-slack-channel showing that the file-upload guard was checking the wrong thing entirely -- blocking uploads from the plugin's own state directory while allowing `~/.ssh/id_rsa` through without complaint.
 

--- a/marketplace/src/content/blog-posts/two-false-positive-fixes-same-root-cause.md
+++ b/marketplace/src/content/blog-posts/two-false-positive-fixes-same-root-cause.md
@@ -4,6 +4,7 @@ description: "Two separate false-positive alerts, same root cause: monitoring co
 date: "2026-05-11"
 tags: ["docker", "healthchecks", "monitoring", "ci-cd", "observability", "production-engineering"]
 featured: false
+canonical: "https://startaitools.com/posts/two-false-positive-fixes-same-root-cause/"
 ---
 Two separate monitoring failures on the same day, same root cause. Both fixed by answering a single question: "Am I testing for health, or am I testing for perfect conditions?" The distinction matters because perfect conditions are temporary, and health is structural. And once you see the pattern once, you see it everywhere.
 

--- a/marketplace/src/content/blog-posts/two-releases-one-day-intentcad-v060-v070.md
+++ b/marketplace/src/content/blog-posts/two-releases-one-day-intentcad-v060-v070.md
@@ -4,6 +4,7 @@ description: "Shipping two version releases in a single day — 22 commits, 5 EP
 date: "2026-03-07"
 tags: ["ai-agents", "architecture", "python", "release-engineering", "cad"]
 featured: false
+canonical: "https://startaitools.com/posts/two-releases-one-day-intentcad-v060-v070/"
 ---
 You don't ship two releases in one day by working twice as fast. You ship them because the architecture lets you.
 

--- a/marketplace/src/content/blog-posts/ubuntu-development-journey-timeline.md
+++ b/marketplace/src/content/blog-posts/ubuntu-development-journey-timeline.md
@@ -4,6 +4,7 @@ description: "The Evolution of a Development Machine: 20 Days from Ubuntu Instal
 date: "2025-09-14"
 tags: ["ubuntu", "development", "devops", "journey", "productivity"]
 featured: false
+canonical: "https://startaitools.com/posts/the-evolution-of-a-development-machine-20-days-from-ubuntu-install-to-production-powerhouse/"
 ---
 ## The Journey: From Fresh Ubuntu to Full-Stack Development Environment
 

--- a/marketplace/src/content/blog-posts/unicode-hygiene-gate-same-day-trapdoor-defense.md
+++ b/marketplace/src/content/blog-posts/unicode-hygiene-gate-same-day-trapdoor-defense.md
@@ -4,6 +4,7 @@ description: "Schema validation can't see invisible Unicode. A stdlib-only CI ga
 date: "2026-05-24"
 tags: ["ci-cd", "python", "security", "claude-code", "automation"]
 featured: false
+canonical: "https://startaitools.com/posts/unicode-hygiene-gate-same-day-trapdoor-defense/"
 ---
 A schema validator reads parsed structure. It never sees the bytes.
 

--- a/marketplace/src/content/blog-posts/usable-not-just-functional-four-repos-40-commits.md
+++ b/marketplace/src/content/blog-posts/usable-not-just-functional-four-repos-40-commits.md
@@ -4,6 +4,7 @@ description: "40+ commits across 4 repos. CAD entity selection gets real boundin
 date: "2026-03-24"
 tags: ["ai-agents", "python", "testing", "architecture", "claude-code", "debugging", "full-stack", "react"]
 featured: false
+canonical: "https://startaitools.com/posts/usable-not-just-functional-four-repos-40-commits/"
 ---
 Functional is table stakes. Usable is the moat.
 

--- a/marketplace/src/content/blog-posts/v1-release-gate-conditional-go.md
+++ b/marketplace/src/content/blog-posts/v1-release-gate-conditional-go.md
@@ -4,6 +4,7 @@ description: "Why release gates should accept GO with conditions, not binary GO/
 date: "2026-05-18"
 tags: ["release-engineering", "ci-cd", "typescript", "testing", "monorepo"]
 featured: false
+canonical: "https://startaitools.com/posts/v1-release-gate-conditional-go/"
 ---
 Two beads were open at the start of 2026-05-18. E10-B11 was the v1.0 release-readiness gate. E10-B12 was the v1.0 release cut, blocked-by-design on B11. Epic 10 was the last epic in `intentional-cognition-os` (ICO). The release pipeline was wired through `/release`. Everything that mattered had to clear one ritual.
 

--- a/marketplace/src/content/blog-posts/verified-plugins-program-quality-signal-for-the-marketplace.md
+++ b/marketplace/src/content/blog-posts/verified-plugins-program-quality-signal-for-the-marketplace.md
@@ -4,6 +4,7 @@ description: "A plugin marketplace without quality signals is a junk drawer. The
 date: "2026-03-09"
 tags: ["web-development", "architecture", "ci-cd", "claude-code", "automation"]
 featured: false
+canonical: "https://startaitools.com/posts/verified-plugins-program-quality-signal-for-the-marketplace/"
 ---
 A plugin marketplace without quality signals is a junk drawer.
 

--- a/marketplace/src/content/blog-posts/vite-dev-server-in-production-the-871-byte-tell.md
+++ b/marketplace/src/content/blog-posts/vite-dev-server-in-production-the-871-byte-tell.md
@@ -4,6 +4,7 @@ description: "scorecardecho.com shipped the Vite dev server to every visitor. Th
 date: "2026-05-27"
 tags: ["vite", "docker", "production", "diagnostics", "frontend"]
 featured: false
+canonical: "https://startaitools.com/posts/vite-dev-server-in-production-the-871-byte-tell/"
 ---
 
 ## The 871-byte tell

--- a/marketplace/src/content/blog-posts/vps-as-the-home-day-1-eight-deploy-iterations.md
+++ b/marketplace/src/content/blog-posts/vps-as-the-home-day-1-eight-deploy-iterations.md
@@ -4,6 +4,7 @@ description: "8 GitHub Actions iterations to land Tailscale OIDC + a cross-repo 
 date: "2026-05-01"
 tags: ["devops", "ci-cd", "release-engineering", "tailscale", "github-actions", "infrastructure"]
 featured: false
+canonical: "https://startaitools.com/posts/vps-as-the-home-day-1-eight-deploy-iterations/"
 ---
 Day 1 of VPS-as-the-Home was the launch of a 9-priority program: consolidate Intent Solutions hosting onto a single Contabo VPS, execute the GCP exodus, and harden every active repo's deploy posture. The deploy pipeline cost 8 GitHub Actions run iterations across two priorities to land what should have been one. The plan-v4.1 rewrite — adding testing as a first-class requirement after the user surfaced that `cd <random-repo> && git push` should "just work" — was the discipline that survived contact with reality.
 

--- a/marketplace/src/content/blog-posts/when-best-work-invisible-mining-education-own-projects.md
+++ b/marketplace/src/content/blog-posts/when-best-work-invisible-mining-education-own-projects.md
@@ -4,6 +4,7 @@ description: "The humbling realization that I'd written comprehensive educationa
 date: "2025-10-07"
 tags: ["learning-in-public", "content-strategy", "personal-growth", "career-development"]
 featured: false
+canonical: "https://startaitools.com/posts/when-your-best-work-is-invisible-mining-31kb-of-education-from-my-own-projects/"
 ---
 # When Your Best Work is Invisible
 

--- a/marketplace/src/content/blog-posts/when-green-ci-proves-nothing.md
+++ b/marketplace/src/content/blog-posts/when-green-ci-proves-nothing.md
@@ -4,6 +4,7 @@ description: "CI dogfood for AI-agent governance went green while gating zero to
 date: "2026-06-11"
 tags: ["ci-cd", "ai-agents", "testing", "claude-code", "docker", "devops"]
 featured: false
+canonical: "https://startaitools.com/posts/when-green-ci-proves-nothing/"
 ---
 Your test passed. It gated zero tool calls. It proved nothing.
 

--- a/marketplace/src/content/blog-posts/when-llm-output-lies-instead-of-crashing.md
+++ b/marketplace/src/content/blog-posts/when-llm-output-lies-instead-of-crashing.md
@@ -4,6 +4,7 @@ description: "An LLM-output parsing bug silently understated a cost report via c
 date: "2026-06-27"
 tags: ["python", "claude-code", "ai-agents", "debugging", "databricks"]
 featured: false
+canonical: "https://startaitools.com/posts/when-llm-output-lies-instead-of-crashing/"
 ---
 Yesterday's post established that the LLM should never do the math—the `databricks-cost-leak-hunter` skill computes confirmed dollars via a SQL join to the customer's billing tables, not estimates. Bulletproof arithmetic.
 

--- a/marketplace/src/content/blog-posts/write-once-publish-everywhere-content-distribution-infra.md
+++ b/marketplace/src/content/blog-posts/write-once-publish-everywhere-content-distribution-infra.md
@@ -4,6 +4,7 @@ description: "Three sites now share content through automated pipelines: Hugo to
 date: "2026-03-25"
 tags: ["automation", "architecture", "ci-cd", "web-development", "claude-code"]
 featured: false
+canonical: "https://startaitools.com/posts/write-once-publish-everywhere-content-distribution-infra/"
 ---
 Three websites. One hundred blog posts. Thirty-one field notes. Four plugin repos. All synced automatically. None of it existed yesterday.
 

--- a/marketplace/src/content/blog-posts/wrong-mode-green-is-not-a-gate.md
+++ b/marketplace/src/content/blog-posts/wrong-mode-green-is-not-a-gate.md
@@ -4,6 +4,7 @@ description: "A freshness gate that accepts the wrong mode flag and still exits 
 date: "2026-07-22"
 tags: ["testing", "ci-cd", "python", "architecture", "debugging", "claude-code"]
 featured: false
+canonical: "https://startaitools.com/posts/wrong-mode-green-is-not-a-gate/"
 ---
 A green board is not a gate if the checker ran the wrong mode.
 

--- a/marketplace/src/content/blog-posts/x-bug-triage-plugin-zero-to-v043-one-day.md
+++ b/marketplace/src/content/blog-posts/x-bug-triage-plugin-zero-to-v043-one-day.md
@@ -4,6 +4,7 @@ description: "A brand-new MCP plugin that triages X/Twitter bug reports shipped 
 date: "2026-03-23"
 tags: ["ai-agents", "typescript", "testing", "architecture", "claude-code", "automation"]
 featured: false
+canonical: "https://startaitools.com/posts/x-bug-triage-plugin-zero-to-v043-one-day/"
 ---
 Thirteen releases. Ten epics. Eighty-nine tests. Four extracted sub-agent skills. One day.
 

--- a/marketplace/src/content/blog-posts/zero-to-ci-full-stack-dashboard-one-session.md
+++ b/marketplace/src/content/blog-posts/zero-to-ci-full-stack-dashboard-one-session.md
@@ -4,6 +4,7 @@ description: "11 commits from empty repo to green CI. Building the Braves Booth 
 date: "2026-03-01"
 tags: ["full-stack", "react", "typescript", "fastapi", "docker", "ci-cd", "architecture"]
 featured: false
+canonical: "https://startaitools.com/posts/zero-to-ci-full-stack-dashboard-one-session/"
 ---
 Empty directory at 8 AM. Green CI pipeline by dinner. 30 commits across two projects. Here's how the day went.
 

--- a/marketplace/src/content/blog-posts/üöä-the-complete-ai-engineering-curriculum-from-zero-to-200k-salary.md
+++ b/marketplace/src/content/blog-posts/üöä-the-complete-ai-engineering-curriculum-from-zero-to-200k-salary.md
@@ -4,6 +4,7 @@ description: "Free comprehensive AI Engineering curriculum covering prompt engin
 date: "2025-09-13"
 tags: ["ai-engineering", "machine-learning", "career-development", "education", "programming", "curriculum"]
 featured: true
+canonical: "https://startaitools.com/posts/the-complete-ai-engineering-curriculum-from-zero-to-200k-salary/"
 ---
 # The AI Engineering Revolution Is Here - And You're Invited 🎯
 

--- a/marketplace/src/pages/blog/[...slug].astro
+++ b/marketplace/src/pages/blog/[...slug].astro
@@ -20,7 +20,7 @@ const dateFormatted = new Date(post.data.date).toLocaleDateString('en-US', {
 });
 ---
 
-<BaseLayout title={title} description={description}>
+<BaseLayout title={title} description={description} canonical={post.data.canonical}>
   <Fragment slot="head">
     <script type="application/ld+json" set:html={JSON.stringify({
       "@context": "https://schema.org",


### PR DESCRIPTION
187 dual-published posts self-canonicalised to tonsofskills.com, so this site and startaitools.com competed for identical content. **startaitools is the canonical publisher** — nothing said so, and Google picks a winner arbitrarily in that situation.

## What changed

| file | change |
|---|---|
| `content.config.ts` | blog-posts schema accepts optional `canonical` |
| `blog/[...slug].astro` | passes it to BaseLayout's `canonical` prop (added in #1132) |
| 176 post files | backfilled with a **sitemap-verified** canonical |

Absent `canonical` = the post is native here and self-canonicalises. 11 posts are in that state, correctly.

## Why explicit and not derived

Deriving from the slug was the obvious approach. **It is wrong twice over.**

**1. Three posts don't exist on startaitools at all.** Verified 404 there, 200 here — they're native. Deriving would aim them at dead URLs, and a canonical pointing at a 404 makes search engines *drop the page*. Strictly worse than the problem being fixed.

**2. The slug doesn't map cleanly.** Of the 176 that do resolve on startaitools, **124 live at their filename slug and 52 at a title-derived one** (an older convention; every post since 2026-02 is filename-slugged):

```
building-254-table-bigquery-schema-72-hours          → 404
building-a-254-table-bigquery-schema-in-72-hours     → 200
```

So every canonical was resolved against the live sitemap rather than computed, and each target fetched before being written.

## Layer touched

Content schema + blog route + content frontmatter. No validator, CI gate, or runtime change. The schema field is optional, so nothing breaks if it's absent.

## Verification & evidence

```
Mapping built from https://startaitools.com/sitemap.xml  (320 live post URLs)
All 52 title-derived targets fetched individually:  52/52 HTTP 200, 0 dead

$ npm run build
[build] 3835 page(s) built  ·  Complete, no errors
```

Rendered canonicals:

```
blog/ai-dev-transformation-part-1-the-mess
  → startaitools.com/posts/from-chaos-to-one-paste-magic-part-1-the-mess-and-why-it-mattered/
blog/now-lms-2-0-and-the-email-cutover
  → startaitools.com/posts/now-lms-2-0-and-the-email-cutover/
blog/welcome-to-the-build-log   (native)
  → tonsofskills.com/blog/welcome-to-the-build-log/
```

**Two near-misses worth recording**, both caught before anything was written:

- An initial 12-way parallel sweep reported **60 false 404s**. Re-checked serially before drawing any conclusion — they were rate-limiting artefacts mixed with the real slug mismatch. No canonical was written on bad data.
- The schema anchor text appears **twice** in `content.config.ts`; a naive replace would also have altered the docs collection. The edit was scoped to `blogPostsCollection` and an assert caught it.

## Risk

Moderate-by-intent, low-by-mechanism. This deliberately concedes those 176 URLs' own ranking on tonsofskills to consolidate signal into the originals — that is the point, and it is the owner's stated call. Mechanically it is one optional frontmatter key; rollback is a single revert.

Expect Google to reassign those pages over the next few crawls rather than instantly.

## Operational impact

None — no env, deps, secrets, migrations, or deploy-order change.

## Paired with

**startaitools.com #51**, which makes the transform emit the canonical so future posts carry it without a backfill.

## Refs

Owner: "startaitools is the canonical publishing, this has to be fixed or it will mess up my SEO with Google."