### PR TITLE
feat(marketplace-site): surface npm downloads in the hero and add the intent solutions io byline

### DIFF
--- a/marketplace/src/pages/index.astro
+++ b/marketplace/src/pages/index.astro
@@ -1072,7 +1072,7 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
     <section class="hero">
         <div class="hero-inner">
             <h1><span class="hero-text-muted">TONS OF</span><br/><span class="hero-text-primary">SKILLS</span></h1>
-            <p class="hero-byline">by <a href="https://jeremylongshore.com" target="_blank" rel="noopener">Jeremy Longshore</a></p>
+            <p class="hero-byline">by <a href="https://jeremylongshore.com" target="_blank" rel="noopener">Jeremy Longshore</a> &middot; <a href="https://intentsolutions.io" target="_blank" rel="noopener">intent solutions io</a></p>
 
             {npmPublished > 0 && (
                 <div class="hero-sponsor-marquee hero-stats-marquee">
@@ -1098,6 +1098,9 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
 
             <p class="hero-subtitle">
                 Agent skills for Claude Code. Search {totalSkills} skills across {totalPlugins} plugins.
+                {npmMonth > 0 && (
+                    <> {fmtNum(npmMonth)} npm downloads across {npmPublished} packages in the last 30 days.</>
+                )}
             </p>
 
             <!-- Hero Search Bar -->


### PR DESCRIPTION
Two hero changes.

## Byline

```
by Jeremy Longshore   →   by Jeremy Longshore · intent solutions io
```

Both clickable — `jeremylongshore.com` and `intentsolutions.io`. **"intent solutions io" is lowercase** per the owner's instruction, deliberately not title-cased.

## Downloads in the subtitle

The skills sentence is **unchanged** — the owner confirmed that part reads fine. The download figure is appended as its own sentence:

> Agent skills for Claude Code. Search 3069 skills across 467 plugins.
> 52,520 npm downloads across 453 packages in the last 30 days.

**Chose to append a sentence rather than join with a separator**, because the existing sentence already ends in a full stop — `plugins. · 52,520` reads as a typo.

## No new data plumbing

`index.astro` already imports `npm-stats.json` and computes `npmMonth` / `npmPublished` / `fmtNum` — they were simply unused in the subtitle. That file is regenerated daily by `scripts/fetch-npm-stats.mjs` via `update-npm-stats.yml`, and the import is already wrapped in try/catch with an empty-shape fallback, so a cold build before the first cron run still succeeds. The render is guarded on `npmMonth > 0`, so that fallback shows the skills sentence alone rather than "0 downloads".

**This is the same source as the skills.sh badge in the README** — `totalMonth: 52520` across `publishedCount: 453` — not a hardcoded number.

## Layer touched

Landing-page presentation only. No schema, validator, CI gate, or runtime change.

## Verification & evidence

```
$ npm run build
[build] 3835 page(s) built  ·  Complete, no errors
```

Rendered `dist/index.html`:

```
hero-byline     by Jeremy Longshore · intent solutions io
hero-subtitle   Agent skills for Claude Code. Search 3069 skills across 467
                plugins. 52,520 npm downloads across 453 packages in the last 30 days.
```

Byline hrefs resolve to `https://jeremylongshore.com` and `https://intentsolutions.io`. Separator emits as `&middot;` — verified **not** double-escaped in the raw HTML (an easy way to end up printing a literal `&middot;` on the page).

## Risk

Very low. Two text nodes in the hero, guarded against missing data. Rollback is a single revert.

## Operational impact

None.

## Known staleness — not introduced here

`npm-stats.json` carries `generatedAt: 2026-07-18` because **the daily refresh PR (#1097) has been open since 2026-07-19 and never merged.** The figure will lag until that lands. Wiring the hero to it doesn't make that worse — it makes it visible. Worth merging #1097.

## Refs

Owner: "the search skills part i pasted is fine its the npm downloads … can we incorporate that", and "intent solutions io is all lower case … make sure they are both clickable links".