### PR TITLE
feat(marketplace-site): band the home zones so the page reads as sections, not one scroll

### DIFF
--- a/marketplace/src/pages/index.astro
+++ b/marketplace/src/pages/index.astro
@@ -1015,6 +1015,64 @@ const fmtNum = (n: number) => n.toLocaleString('en-US');
                 padding: 0.375rem;
             }
         }
+    
+        /* ── Home zone rhythm ────────────────────────────────────────────────
+           The landing page stacked seven card-grid sections at identical visual
+           weight — five of them on the same --surface tone, two with no rule at
+           all, and padding drifting between 3rem and 4rem. Nothing signalled
+           where one zone ended and the next began, so the whole page read as a
+           single undifferentiated scroll no matter how much padding was added.
+
+           Fix is separation BETWEEN zones, not sparsity within them: this is a
+           directory and 3,000+ skills need density. So grid contents are
+           untouched; only the band each grid sits in changes.
+
+             tone      alternates --surface / --surface-1 (both existing OKLCH
+                       tokens; a tone change reads as "new zone" instantly and
+                       does the work margin alone cannot)
+             rhythm    one padding value everywhere, so the eye can tell
+                       "same group" from "new group" purely from the ratio of
+                       card-gap : zone-padding
+
+           Deliberately NOT done here: merging the seven zones down to three.
+           That restructures content and can cost click-through paths, so it is
+           a separate, reviewable change.
+           ------------------------------------------------------------------ */
+        .killer-skills-section,
+        .stash-section,
+        .saas-packs-section,
+        .features {
+            background: var(--surface);
+        }
+
+        .heat-check-section,
+        .cowork-home-section,
+        .level-up-section {
+            background: var(--surface-1);
+        }
+
+        .killer-skills-section,
+        .heat-check-section,
+        .stash-section,
+        .cowork-home-section,
+        .saas-packs-section,
+        .level-up-section,
+        .features {
+            padding: var(--space-10) var(--space-6);
+        }
+
+        @media (max-width: 48rem) {
+            .killer-skills-section,
+            .heat-check-section,
+            .stash-section,
+            .cowork-home-section,
+            .saas-packs-section,
+            .level-up-section,
+            .features {
+                padding: var(--space-8) var(--space-4);
+            }
+        }
+
     </style>
 
     <!-- Schema.org Structured Data -->


### PR DESCRIPTION
The landing page stacked **seven card-grid sections at identical visual weight**. Five sat on the same `--surface` tone, two had *no rule at all*, and padding drifted between 3rem and 4rem. Nothing signalled where one zone ended and the next began.

That is why it read as one undifferentiated scroll — the problem was macro (seven equal-weight blocks), not micro (card polish).

## What changed

**Tone** — zones now alternate, using tokens that already exist:

| zone | band |
|---|---|
| killer-skills | `--bg` |
| heat-check | `--panel` |
| stash | `--bg` |
| cowork-home | `--panel` |
| saas-packs | `--bg` |
| level-up | `--panel` |
| features | `--bg` |

`--surface`/`--surface-1` resolve to `--bg`/`--panel` — existing OKLCH tokens, no new colour, no DESIGN.md drift.

**Rhythm** — one padding value across all seven (`--space-10`/`--space-6`, and `--space-8`/`--space-4` under 48rem), so the eye separates "same group" from "new group" purely from the card-gap : zone-padding ratio.

## Why banding rather than more whitespace

**A tone change reads as "new zone" instantly; margin alone does not** — which is exactly why the existing generous padding never fixed the flatness.

Same reason grid *contents* are untouched: this is a discovery product, 3,000+ skills need density, and the fix is separation **between** zones rather than sparsity **within** them. A directory that feels empty is failing its own job.

**Chose one appended block over editing seven scattered rules** — it wins on source order at equal specificity, keeps the rationale in one place, and reverts as a single hunk.

## Layer touched

Landing-page presentation only. No component, schema, data, CI, or runtime change. Zero markup changes — CSS only.

## Verification & evidence

```
$ npm run build
[build] 3835 page(s) built  ·  Complete, no errors
```

Built CSS — all seven zones present and alternating exactly as tabled above. Band tones confirmed distinct:

```
--bg     = oklch(14.574% 0.0043 285.86)
--panel  = oklch(20.904% 0 0)
```

Padding rule confirmed to win on source order over the two earlier declarations, with the mobile override last. (My first check misread this — it compared my rule against my *own* media query and reported a false loss. Re-verified by position.)

## Risk

Very low. CSS-only, additive, single-hunk revert. The visible change is intentional and immediate.

## Operational impact

None.

## Deliberately not done

**Merging the seven zones down to three.** That restructures content and can silently cost click-through paths to Stash / Cowork / SaaS Packs — chrome can be merged, links cannot be lost. It is a separate, reviewable change and should only follow once the owner has looked at this banding on a real device.

Also out of scope on purpose: typography scale, the orange accent, card treatment. The ask was rhythm, not a rebrand.

## Refs

Owner asked for the page to feel "crisp and sharp like learn.intentsolutions.io". A designer consult confirmed the reference's value is its **rhythm**, not its narrative structure — a directory's job is confirm-and-deliver, so prose bands between landing and search would tax the one action that matters. This takes the rhythm and leaves the marketing.