### PR TITLE
fix(blog): repair 127 dead links in syndicated posts pointing at our own domain

### DIFF
--- a/marketplace/src/content/blog-posts/adversarial-review-before-team-rollout.md
+++ b/marketplace/src/content/blog-posts/adversarial-review-before-team-rollout.md
@@ -298,9 +298,9 @@ The meta-lesson is the method itself. Six independent lenses, each forced to **v
 
 ## Related Posts
 
-- [The Moat Is the Trust Layer: Turning a Local-RAG App into a BYOK Document-Intelligence Platform](/posts/the-moat-is-the-trust-layer-nexus-byok-rag/) — where adversarially reviewing the *graders* caught the eval suite lying green.
-- [Every Safety Gate Has a Failure Direction](/posts/every-safety-gate-has-a-failure-direction/) — why one gate crashes fail-closed on bad data while a swallowed error lets another pass fail-open.
-- [Noise-Robust LLM-Judge Evals: Don't Sign a Coin Flip](/posts/noise-robust-signed-llm-judge-evals/) — on not trusting a measurement you haven't proven can go red.
+- [The Moat Is the Trust Layer: Turning a Local-RAG App into a BYOK Document-Intelligence Platform](/blog/the-moat-is-the-trust-layer-nexus-byok-rag/) — where adversarially reviewing the *graders* caught the eval suite lying green.
+- [Every Safety Gate Has a Failure Direction](/blog/every-safety-gate-has-a-failure-direction/) — why one gate crashes fail-closed on bad data while a swallowed error lets another pass fail-open.
+- [Noise-Robust LLM-Judge Evals: Don't Sign a Coin Flip](/blog/noise-robust-signed-llm-judge-evals/) — on not trusting a measurement you haven't proven can go red.
 
 <script type="application/ld+json">
 {

--- a/marketplace/src/content/blog-posts/cap-drop-all-broke-the-gate-socket.md
+++ b/marketplace/src/content/blog-posts/cap-drop-all-broke-the-gate-socket.md
@@ -154,9 +154,9 @@ The same day, away from the gate socket:
 
 ## Related posts
 
-- [When Green CI Proves Nothing](/posts/when-green-ci-proves-nothing/) — the gate that counts only counts what reaches it
-- [Honor the Gate When the Verdict Is Inconvenient](/posts/honor-the-gate-when-the-verdict-is-inconvenient/)
-- [HITL Delivery Is a Fail-Closed, Exactly-Once Problem](/posts/hitl-delivery-is-a-fail-closed-exactly-once-problem/)
+- [When Green CI Proves Nothing](/blog/when-green-ci-proves-nothing/) — the gate that counts only counts what reaches it
+- [Honor the Gate When the Verdict Is Inconvenient](/blog/honor-the-gate-when-the-verdict-is-inconvenient/)
+- [HITL Delivery Is a Fail-Closed, Exactly-Once Problem](/blog/hitl-delivery-is-a-fail-closed-exactly-once-problem/)
 
 <script type="application/ld+json">
 {

--- a/marketplace/src/content/blog-posts/checkout-image-volume-three-way-drift.md
+++ b/marketplace/src/content/blog-posts/checkout-image-volume-three-way-drift.md
@@ -84,7 +84,7 @@ The fix was dropping `| urlencode` from the address while keeping it on the subj
 
 First, identity. `docker compose exec -T app cat /app/BUILD_SHA` must equal `git rev-parse HEAD` on the checkout. If the file is absent at all, it fails with "image predates the provable deploy work" rather than skipping the check.
 
-Second, liveness. The container health status must be `healthy`. That check is necessary and nowhere near sufficient, for [the reason a health endpoint is not a correctness signal](/posts/liveness-without-health-is-theater/): this container was healthy the entire time it served the wrong files.
+Second, liveness. The container health status must be `healthy`. That check is necessary and nowhere near sufficient, for [the reason a health endpoint is not a correctness signal](/blog/liveness-without-health-is-theater/): this container was healthy the entire time it served the wrong files.
 
 Third, and this is the one that changes how the whole thing behaves: the served page must carry markers that only the current commit can produce. It is fetched through the same loopback and header path that Caddy uses, so the assertion runs against the real request path:
 
@@ -99,7 +99,7 @@ Four assertions on that response body:
 3. The Credly badge iframe marker `embedded_badge` is present. This one specifically proves the volume refresh landed, because the stale volume copy predates the badge entirely.
 4. Neither `unpkg.com` nor `cdn.jsdelivr.net` appears anywhere in the response.
 
-The first two checks, identity and liveness, are about the container. This third check, the four assertions above, is about the bytes on the wire. A deploy check that only asks the orchestrator whether it is happy cannot detect a volume shadowing an image, because from the orchestrator's point of view nothing is wrong. You have to assert on what the user receives, and the assertion has to name a marker that only the new commit can produce. "The page returned 200" would have passed happily for the entire period the site was stale. A check that runs is not the same thing as a check that [validates something](/posts/passing-is-not-validating/).
+The first two checks, identity and liveness, are about the container. This third check, the four assertions above, is about the bytes on the wire. A deploy check that only asks the orchestrator whether it is happy cannot detect a volume shadowing an image, because from the orchestrator's point of view nothing is wrong. You have to assert on what the user receives, and the assertion has to name a marker that only the new commit can produce. "The page returned 200" would have passed happily for the entire period the site was stale. A check that runs is not the same thing as a check that [validates something](/blog/passing-is-not-validating/).
 
 ## The gate that failed its own first run
 

--- a/marketplace/src/content/blog-posts/coverage-vs-mutation-testing-rules-engine.md
+++ b/marketplace/src/content/blog-posts/coverage-vs-mutation-testing-rules-engine.md
@@ -38,7 +38,7 @@ A *mutant* is a one-character change: `===` becomes `!==`, `&&` becomes `||`, a 
 
 The 301 mutants in the engine were all no-coverage. Stryker never even got to run them against a test, because there was no unit test visiting that file.
 
-Meanwhile, the repo's overall line coverage sat at 69.09%—and the engine's lines were executed via the E2E path, counting toward that number. Coverage says "this line ran." Mutation testing says "this line's behavior is pinned down by assertions"—call it assertion coverage. They are not the same metric, and a [green CI run](/posts/when-green-ci-proves-nothing/) only tells you about the first.
+Meanwhile, the repo's overall line coverage sat at 69.09%—and the engine's lines were executed via the E2E path, counting toward that number. Coverage says "this line ran." Mutation testing says "this line's behavior is pinned down by assertions"—call it assertion coverage. They are not the same metric, and a [green CI run](/blog/when-green-ci-proves-nothing/) only tells you about the first.
 
 ## The Stryker Setup
 
@@ -64,7 +64,7 @@ Meanwhile, the repo's overall line coverage sat at 69.09%—and the engine's lin
 
 The `mutate` array targets four high-value pure-logic files. Stryker baseline runs in ~30 seconds. The `break: null` is deliberate: report the score, but do not fail CI. Establish a baseline first. Ratchet later.
 
-This is the inverse of the "fail immediately on every finding" instinct. A fresh gate that blocks on day one gets disabled by the next engineer. Report-only first. Let the team see the numbers. Then make it enforceable—and [honor the gate](/posts/honor-the-gate-when-the-verdict-is-inconvenient/) when its verdict is inconvenient.
+This is the inverse of the "fail immediately on every finding" instinct. A fresh gate that blocks on day one gets disabled by the next engineer. Report-only first. Let the team see the numbers. Then make it enforceable—and [honor the gate](/blog/honor-the-gate-when-the-verdict-is-inconvenient/) when its verdict is inconvenient.
 
 ## Why E2E Wasn't Enough
 
@@ -131,9 +131,9 @@ Coverage measures attendance. Mutation testing measures whether anyone was payin
 
 ## Related Posts
 
-- [Green CI Proves Nothing: Why Your Tests Gate Zero Calls](/posts/when-green-ci-proves-nothing/) — a passing test suite that asserts on nothing.
-- [Honor the Gate When the Verdict Is Inconvenient](/posts/honor-the-gate-when-the-verdict-is-inconvenient/) — the discipline of trusting the gate's verdict.
-- [When LLM Output Lies Instead of Crashing](/posts/when-llm-output-lies-instead-of-crashing/) — the same intent-mail codebase: "it ran without erroring" is not "it's correct."
+- [Green CI Proves Nothing: Why Your Tests Gate Zero Calls](/blog/when-green-ci-proves-nothing/) — a passing test suite that asserts on nothing.
+- [Honor the Gate When the Verdict Is Inconvenient](/blog/honor-the-gate-when-the-verdict-is-inconvenient/) — the discipline of trusting the gate's verdict.
+- [When LLM Output Lies Instead of Crashing](/blog/when-llm-output-lies-instead-of-crashing/) — the same intent-mail codebase: "it ran without erroring" is not "it's correct."
 
 <script type="application/ld+json">
 {

--- a/marketplace/src/content/blog-posts/dependabot-pile-up-fix-the-policy.md
+++ b/marketplace/src/content/blog-posts/dependabot-pile-up-fix-the-policy.md
@@ -65,5 +65,5 @@ The measure of the fix is not the empty board today. It's whether next month's r
 
 ## Related Posts
 
-- [Backlog Zero: Burning Down the Estate with a Triage Machine](/posts/backlog-zero-estate-triage-machine/)
-- [Every Safety Gate Has a Failure Direction](/posts/every-safety-gate-has-a-failure-direction/)
+- [Backlog Zero: Burning Down the Estate with a Triage Machine](/blog/backlog-zero-estate-triage-machine/)
+- [Every Safety Gate Has a Failure Direction](/blog/every-safety-gate-has-a-failure-direction/)

--- a/marketplace/src/content/blog-posts/do-not-blindly-restart.md
+++ b/marketplace/src/content/blog-posts/do-not-blindly-restart.md
@@ -128,6 +128,6 @@ Outside the watchdog incident, three smaller things landed the same day.
 
 ## Related posts
 
-- [Exit 0 Is Not Success](/posts/exit-0-is-not-success/)
-- [A Green Recovery Drill Can Still Be Lying](/posts/a-green-recovery-drill-can-still-be-lying/)
-- [Liveness Without Health Is Theater](/posts/liveness-without-health-is-theater/)
+- [Exit 0 Is Not Success](/blog/exit-0-is-not-success/)
+- [A Green Recovery Drill Can Still Be Lying](/blog/a-green-recovery-drill-can-still-be-lying/)
+- [Liveness Without Health Is Theater](/blog/liveness-without-health-is-theater/)

--- a/marketplace/src/content/blog-posts/empty-is-not-clean.md
+++ b/marketplace/src/content/blog-posts/empty-is-not-clean.md
@@ -165,6 +165,6 @@ That's the throughline for all of it. Guardrails for an AI agent are not feature
 
 ## Related posts
 
-- [Every Safety Gate Has a Failure Direction](/posts/every-safety-gate-has-a-failure-direction/) — the underlying principle: every gate fails in *some* direction, and you have to choose it on purpose.
-- [Adversarial Review Before Team Rollout](/posts/adversarial-review-before-team-rollout/) — all five of these bugs came from pointing hostile reviewers at the core before anyone depended on it.
-- [When a Relevance Score Broke the Cite-or-Refuse Gate](/posts/relevance-score-broke-cite-or-refuse-gate/) — another fail-open gate, another case of absence quietly reading as permission.
+- [Every Safety Gate Has a Failure Direction](/blog/every-safety-gate-has-a-failure-direction/) — the underlying principle: every gate fails in *some* direction, and you have to choose it on purpose.
+- [Adversarial Review Before Team Rollout](/blog/adversarial-review-before-team-rollout/) — all five of these bugs came from pointing hostile reviewers at the core before anyone depended on it.
+- [When a Relevance Score Broke the Cite-or-Refuse Gate](/blog/relevance-score-broke-cite-or-refuse-gate/) — another fail-open gate, another case of absence quietly reading as permission.

--- a/marketplace/src/content/blog-posts/eval-gated-model-swap-gpt-5-4.md
+++ b/marketplace/src/content/blog-posts/eval-gated-model-swap-gpt-5-4.md
@@ -57,6 +57,6 @@ Cost: ~$0.079/report (~3x gpt-4o) but under 2% of the $4.99 ticket. Rollback is 
 
 ## Related Posts
 
-- [BM25 Before Vectors: An Eval-Gated Retrieval ADR](/posts/bm25-before-vectors-retrieval-backend-adr/) — the same "gate the decision on an eval" discipline, applied to a retrieval backend.
-- [Run the Readiness Audit Before You Flip DNS](/posts/readiness-audit-before-the-dns-flip/) — the DiagnosticPro self-host rollout, one door earlier.
-- [The LLM Should Never Do the Math](/posts/llm-never-does-the-math/) — where to draw the line on what the model is allowed to decide.
+- [BM25 Before Vectors: An Eval-Gated Retrieval ADR](https://startaitools.com/posts/bm25-before-vectors-retrieval-backend-adr/) — the same "gate the decision on an eval" discipline, applied to a retrieval backend.
+- [Run the Readiness Audit Before You Flip DNS](/blog/readiness-audit-before-the-dns-flip/) — the DiagnosticPro self-host rollout, one door earlier.
+- [The LLM Should Never Do the Math](https://startaitools.com/posts/llm-never-does-the-math/) — where to draw the line on what the model is allowed to decide.

--- a/marketplace/src/content/blog-posts/every-safety-gate-has-a-failure-direction.md
+++ b/marketplace/src/content/blog-posts/every-safety-gate-has-a-failure-direction.md
@@ -136,9 +136,9 @@ In parallel, a control-bypass after-action was filed in the `intent-os` governan
 
 ## Related Reading
 
-- [The Relevance Score That Broke Our Cite-or-Refuse Gate](/posts/relevance-score-broke-cite-or-refuse-gate/)
-- [Gate the Statement, Not the Tool Name](/posts/gate-the-statement-not-the-tool-name/)
-- [Human-in-the-Loop Is a Delivery Guarantee, Not a UI Feature](/posts/hitl-delivery-is-a-fail-closed-exactly-once-problem/)
+- [The Relevance Score That Broke Our Cite-or-Refuse Gate](/blog/relevance-score-broke-cite-or-refuse-gate/)
+- [Gate the Statement, Not the Tool Name](/blog/gate-the-statement-not-the-tool-name/)
+- [Human-in-the-Loop Is a Delivery Guarantee, Not a UI Feature](/blog/hitl-delivery-is-a-fail-closed-exactly-once-problem/)
 
 <script type="application/ld+json">
 {

--- a/marketplace/src/content/blog-posts/exit-0-is-not-success.md
+++ b/marketplace/src/content/blog-posts/exit-0-is-not-success.md
@@ -21,7 +21,7 @@ They are bad at the question operators actually care about:
 - Did the export write the expected tables, not an empty stub?
 - Did the watchdog that was supposed to catch all of the above still run?
 
-If your only gate is the process exit code, every one of those can fail while the dashboard stays green. We already ship that lesson in other forms ([empty data that passed as clean](/posts/empty-is-not-clean/), [liveness without health](/posts/liveness-without-health-is-theater/), [gates that fail open](/posts/every-safety-gate-has-a-failure-direction/)). Automation was the next place the same shape showed up.
+If your only gate is the process exit code, every one of those can fail while the dashboard stays green. We already ship that lesson in other forms ([empty data that passed as clean](/blog/empty-is-not-clean/), [liveness without health](/blog/liveness-without-health-is-theater/), [gates that fail open](/blog/every-safety-gate-has-a-failure-direction/)). Automation was the next place the same shape showed up.
 
 ## What we shipped: independent outcome verification
 
@@ -96,6 +96,6 @@ Exit 0 means the process finished. Outcome verification means the work finished.
 
 ## Related Posts
 
-- [Empty Is Not Clean: Five Fail-Open Bugs in an AI Agent](/posts/empty-is-not-clean/)
-- [Liveness Without Health Is Theater](/posts/liveness-without-health-is-theater/)
-- [Every Safety Gate Has a Failure Direction](/posts/every-safety-gate-has-a-failure-direction/)
+- [Empty Is Not Clean: Five Fail-Open Bugs in an AI Agent](/blog/empty-is-not-clean/)
+- [Liveness Without Health Is Theater](/blog/liveness-without-health-is-theater/)
+- [Every Safety Gate Has a Failure Direction](/blog/every-safety-gate-has-a-failure-direction/)

--- a/marketplace/src/content/blog-posts/gate-the-statement-not-the-tool-name.md
+++ b/marketplace/src/content/blog-posts/gate-the-statement-not-the-tool-name.md
@@ -112,9 +112,9 @@ So gate the statement. Enumerate the safe verbs, default-deny everything you can
 
 ## Related posts
 
-- [The LLM Should Never Do the Math](/posts/llm-never-does-the-math/)
-- [When LLM Output Lies Instead of Crashing](/posts/when-llm-output-lies-instead-of-crashing/)
-- [Coverage vs Mutation Testing](/posts/coverage-vs-mutation-testing-rules-engine/)
+- [The LLM Should Never Do the Math](https://startaitools.com/posts/llm-never-does-the-math/)
+- [When LLM Output Lies Instead of Crashing](/blog/when-llm-output-lies-instead-of-crashing/)
+- [Coverage vs Mutation Testing](/blog/coverage-vs-mutation-testing-rules-engine/)
 
 <script type="application/ld+json">
 {

--- a/marketplace/src/content/blog-posts/guidewire-mcp-v0-1-0-foundation-ship.md
+++ b/marketplace/src/content/blog-posts/guidewire-mcp-v0-1-0-foundation-ship.md
@@ -275,4 +275,4 @@ Issue tracker, blueprint set, and roadmap are all in the repo. The next cut is E
 
 - [Claude Code Plugin Marketplace Launch](/blog/claude-code-plugin-marketplace-launch/) — the marketplace this plugin and its sister-pack ship through
 - [Building a Production-Ready Research Tool That Outperforms Anthropic's](/blog/building-production-ready-research-tool-outperforms-anthropic/) — another MCP-fronted system, different domain
-- [IRSB Ecosystem](/irsb-ecosystem/) — companion ecosystem hub for the broader Intent Solutions integration story
+- [IRSB Ecosystem](https://startaitools.com/irsb-ecosystem/) — companion ecosystem hub for the broader Intent Solutions integration story

--- a/marketplace/src/content/blog-posts/hitl-delivery-is-a-fail-closed-exactly-once-problem.md
+++ b/marketplace/src/content/blog-posts/hitl-delivery-is-a-fail-closed-exactly-once-problem.md
@@ -177,7 +177,7 @@ Move 4 is the non-negotiable one. Anything that gates an action must treat the a
 
 The convergence is the evidence. When two systems built for mirror-image roles — one delivering replies out, one receiving approvals in — arrive at the same discipline, and one explicitly cites the other, that is not a local trick. It is the shape of the problem. And the discipline it demands is non-negotiable: an agent you can't trust to fail safely is an agent you can't deploy.
 
-Both shipped clean. CCSC's `slack-delivery.ts` hit 100% line coverage; the test suite grew from 1127 to 1133 tests across the three PRs with all nine gates green each time, and the durable path was extracted to `executeReplyDurablePath` to keep `executeReply` under CRAP 30. AGP landed at 88.89% function / 91.43% line coverage — over the repo's configured floor — with typecheck, Biome, claim-scan, harness verify, and escape-scan all green. The PR sequencing in CCSC is itself the lesson: #228 wired the poller into the runtime without touching the reply tool path ([machinery live but dormant](/posts/ship-dormant-wire-later-multi-agent-slack/)), #229 added the tested building block plus the ADR (design-first), #230 flipped `executeReply` to route through it. The security-sensitive change got its own isolated PR. Ship dormant, wire later.
+Both shipped clean. CCSC's `slack-delivery.ts` hit 100% line coverage; the test suite grew from 1127 to 1133 tests across the three PRs with all nine gates green each time, and the durable path was extracted to `executeReplyDurablePath` to keep `executeReply` under CRAP 30. AGP landed at 88.89% function / 91.43% line coverage — over the repo's configured floor — with typecheck, Biome, claim-scan, harness verify, and escape-scan all green. The PR sequencing in CCSC is itself the lesson: #228 wired the poller into the runtime without touching the reply tool path ([machinery live but dormant](https://startaitools.com/posts/ship-dormant-wire-later-multi-agent-slack/)), #229 added the tested building block plus the ADR (design-first), #230 flipped `executeReply` to route through it. The security-sensitive change got its own isolated PR. Ship dormant, wire later.
 
 ## Also shipped
 
@@ -185,9 +185,9 @@ The same day, `claude-code-plugins` landed a deterministic-CI grading track: a `
 
 ## Related Posts
 
-- [Ship Dormant, Wire Later — A Multi-Agent Slack Production Day](/posts/ship-dormant-wire-later-multi-agent-slack/)
-- [Making Agents Reliable on Real-Device Clouds](/posts/making-agents-reliable-on-real-device-clouds/)
-- [Safety Model First: 16-Tool Ops MCP, One Day](/posts/server-ops-mcp-safety-before-tools/)
+- [Ship Dormant, Wire Later — A Multi-Agent Slack Production Day](https://startaitools.com/posts/ship-dormant-wire-later-multi-agent-slack/)
+- [Making Agents Reliable on Real-Device Clouds](https://startaitools.com/posts/making-agents-reliable-on-real-device-clouds/)
+- [Safety Model First: 16-Tool Ops MCP, One Day](/blog/server-ops-mcp-safety-before-tools/)
 
 <script type="application/ld+json">
 {

--- a/marketplace/src/content/blog-posts/honor-the-gate-when-the-verdict-is-inconvenient.md
+++ b/marketplace/src/content/blog-posts/honor-the-gate-when-the-verdict-is-inconvenient.md
@@ -77,7 +77,7 @@ Then Stryker hit a wall: v9 cannot instrument this Bun/TS codebase. The babel in
 
 That left exactly three options for the new "Mutation testing" CI check:
 
-1. Leave it **permanently red**—every PR shows a failing check that means nothing. The team learns to ignore red checks. This is exactly [alert fatigue](/posts/stop-crying-wolf-3-strike-uptime-monitor-gate/), and it kills every gate downstream.
+1. Leave it **permanently red**—every PR shows a failing check that means nothing. The team learns to ignore red checks. This is exactly [alert fatigue](/blog/stop-crying-wolf-3-strike-uptime-monitor-gate/), and it kills every gate downstream.
 2. Make it **fake-green**—`continue-on-error: true` or a script that always exits 0. A green checkmark that lies. The label says "Mutation testing passed" when mutation testing never ran.
 3. **Remove the check**—keep the stryker.config.json and mutation-gate.sh as hash-pinned scaffolding, document the toolchain block in tests/TESTING.md, and file a tracked bead to re-wire it when a Bun-compatible runner exists.
 
@@ -87,7 +87,7 @@ The commit message: *"A permanently-red OR fake-green 'Mutation testing' check b
 
 The actual deliverable—the BDD acceptance layer—shipped unaffected. All the real hard gates passed: typecheck, biome lint, coverage-gate at 91.43%, claim-scan, doc-drift audit, harness verify, escape-scan (REFUSE=0, CHALLENGE=0).
 
-The transferable point: a green checkmark is a claim. "Mutation testing passed" has to *mean* [mutation testing](/posts/manifest-system-mutation-testing-pyramid/) ran. If a tool can't run against your codebase, a check that always passes is worse than no check. It launders trust. Removing it (with scaffolding retained and a tracked bead filed) is the honest move, not a regression.
+The transferable point: a green checkmark is a claim. "Mutation testing passed" has to *mean* [mutation testing](/blog/manifest-system-mutation-testing-pyramid/) ran. If a tool can't run against your codebase, a check that always passes is worse than no check. It launders trust. Removing it (with scaffolding retained and a tracked bead filed) is the honest move, not a regression.
 
 ## The Parallel
 
@@ -125,9 +125,9 @@ The semantic-flux gate cost ~$4 and saved a possible $2–5K of motivated spendi
 
 ## Related Posts
 
-- [The Wrong Product, Built Perfectly](/posts/the-wrong-product-built-perfectly/)
-- [Honest Perf Benchmarks for a Paid-API Compiler](/posts/honest-perf-benchmarks-paid-api-compiler/)
-- [Manifest System + Mutation Testing: Two Ways to Find Out What Actually Works](/posts/manifest-system-mutation-testing-pyramid/)
+- [The Wrong Product, Built Perfectly](/blog/the-wrong-product-built-perfectly/)
+- [Honest Perf Benchmarks for a Paid-API Compiler](/blog/honest-perf-benchmarks-paid-api-compiler/)
+- [Manifest System + Mutation Testing: Two Ways to Find Out What Actually Works](/blog/manifest-system-mutation-testing-pyramid/)
 
 <script type="application/ld+json">
 {

--- a/marketplace/src/content/blog-posts/let-the-model-judge-make-the-code-decide.md
+++ b/marketplace/src/content/blog-posts/let-the-model-judge-make-the-code-decide.md
@@ -198,6 +198,6 @@ The tell that you have it backwards is comfort. If your pipeline feels clean bec
 
 **Related posts:**
 
-- [Exit 0 Is Not Success](/posts/exit-0-is-not-success/)
-- [Copying Files Is Not Installing](/posts/copying-files-is-not-installing/)
-- [Producer Fallback: When Claude Hits the Weekly Limit](/posts/producer-fallback-when-claude-hits-weekly-limit/)
+- [Exit 0 Is Not Success](/blog/exit-0-is-not-success/)
+- [Copying Files Is Not Installing](/blog/copying-files-is-not-installing/)
+- [Producer Fallback: When Claude Hits the Weekly Limit](/blog/producer-fallback-when-claude-hits-weekly-limit/)

--- a/marketplace/src/content/blog-posts/llm-legible-deterministic-architecture.md
+++ b/marketplace/src/content/blog-posts/llm-legible-deterministic-architecture.md
@@ -22,7 +22,7 @@ Decision log entry 033 ratified that doctrine. It did not add machinery. It adde
 
 The load-bearing rule is D88: deterministic backpressure at every trust boundary. Invalid data, missing authority, an illegal state transition, incomplete required evidence, and ambiguous ownership all get rejected before they become durable state. Partial external failure preserves the partial truth it does have and reports itself as degraded. It never invents completeness.
 
-Read that last sentence twice, because it is the operator's version of a health inspection. A kitchen that is missing half its prep does not open and hope. It reports "not ready" loudly. A collector that reached three of five sources does not write a number as if it saw all five. It records what it saw, marks the rest unknown, and says so. The opposite move, a check that reports success in [the wrong mode](/posts/wrong-mode-green-is-not-a-gate/), is worse than no check at all.
+Read that last sentence twice, because it is the operator's version of a health inspection. A kitchen that is missing half its prep does not open and hope. It reports "not ready" loudly. A collector that reached three of five sources does not write a number as if it saw all five. It records what it saw, marks the rest unknown, and says so. The opposite move, a check that reports success in [the wrong mode](/blog/wrong-mode-green-is-not-a-gate/), is worse than no check at all.
 
 The doctrine spells out the boundary response as a table, and the table is the useful part:
 
@@ -137,7 +137,7 @@ The lesson is portable. If you are running agents against a real system, at some
 
 ## Related Posts
 
-- [Wrong mode green is not a gate](/posts/wrong-mode-green-is-not-a-gate/): when a check reports success in the wrong mode, it is worse than no check.
-- [Passing is not validating](/posts/passing-is-not-validating/): why a green test suite cannot close an operational promise.
-- [A green recovery drill can still be lying](/posts/a-green-recovery-drill-can-still-be-lying/): proving a restore actually restored, not just exited zero.
-- [Let the model judge, make the code decide](/posts/let-the-model-judge-make-the-code-decide/): where the deterministic boundary sits between an LLM's opinion and the gate that acts on it.
+- [Wrong mode green is not a gate](/blog/wrong-mode-green-is-not-a-gate/): when a check reports success in the wrong mode, it is worse than no check.
+- [Passing is not validating](/blog/passing-is-not-validating/): why a green test suite cannot close an operational promise.
+- [A green recovery drill can still be lying](/blog/a-green-recovery-drill-can-still-be-lying/): proving a restore actually restored, not just exited zero.
+- [Let the model judge, make the code decide](/blog/let-the-model-judge-make-the-code-decide/): where the deterministic boundary sits between an LLM's opinion and the gate that acts on it.

--- a/marketplace/src/content/blog-posts/locked-out-of-a-free-course.md
+++ b/marketplace/src/content/blog-posts/locked-out-of-a-free-course.md
@@ -105,7 +105,7 @@ s.add(
 
 The bug is pinned where members would feel it, not where the code happens to be convenient to test.
 
-And it was [mutation-checked](/posts/coverage-vs-mutation-testing-rules-engine/), which is the part most teams skip. Restore the pre-fix `db/tools.py`, run the pin test: it fails exactly the way members experienced it, link count zero, enroll button present. Restore the fix: green. A test that has never failed for the right reason is not yet a test.
+And it was [mutation-checked](/blog/coverage-vs-mutation-testing-rules-engine/), which is the part most teams skip. Restore the pre-fix `db/tools.py`, run the pin test: it fails exactly the way members experienced it, link count zero, enroll button present. Restore the fix: green. A test that has never failed for the right reason is not yet a test.
 
 Deps live in `e2e/requirements.txt` outside the hash-pinned `test.lock`, because playwright wheels are platform-variant. The job shipped advisory, labelled that way in the workflow, which mattered a few hours later.
 
@@ -147,7 +147,7 @@ This is adjacent work that shipped the same day, and the sequencing decision is 
 
 The best of the four: the intake's rate-limit bucket sweep ran on every request and walked every bucket while holding the lock. An attacker holding N live buckets (one IPv6 /64 is enough) made every later POST an O(N) critical section. The anti-spam control becomes the amplifier. Now it sweeps on a 60 second interval with a hard 10k-bucket cap and oldest-first eviction.
 
-Also shipped in that commit: an https scheme check before `urlopen` (the `# nosec B310` there was suppressing exactly the check that would catch a misconfigured `file://` webhook), gitleaks pinned to a digest and the review action pinned to a commit SHA (that action receives a secret and holds `pull-requests: write`, so a moved tag is the worst case), and `deploy-smoke.sh` dropped its 404 arm, because a missing course 302s identically, so a 404 could only mean the blueprint stopped registering, which is the exact regression the smoke exists to catch and the arm was swallowing. That last one belongs with the lockout: [a check that accepted the failure it was written to detect](/posts/every-safety-gate-has-a-failure-direction/).
+Also shipped in that commit: an https scheme check before `urlopen` (the `# nosec B310` there was suppressing exactly the check that would catch a misconfigured `file://` webhook), gitleaks pinned to a digest and the review action pinned to a commit SHA (that action receives a secret and holds `pull-requests: write`, so a moved tag is the worst case), and `deploy-smoke.sh` dropped its 404 arm, because a missing course 302s identically, so a 404 could only mean the blueprint stopped registering, which is the exact regression the smoke exists to catch and the arm was swallowing. That last one belongs with the lockout: [a check that accepted the failure it was written to detect](/blog/every-safety-gate-has-a-failure-direction/).
 
 ## Three failures, one shape: surfaces the checks could not see
 
@@ -163,6 +163,6 @@ The transferable lesson sits in one place: the lockout, the compose regression, 
 
 ## Related Posts
 
-- [When LLM Output Lies Instead of Crashing](/posts/when-llm-output-lies-instead-of-crashing/) : another failure class that returns success while being wrong
-- [Two False-Positive Fixes, Same Root Cause](/posts/two-false-positive-fixes-same-root-cause/) : checks that pass for the wrong reason
-- [Verify the System Map Against Live Infra](/posts/verify-system-map-against-live-infra/) : measuring reality instead of trusting the document
+- [When LLM Output Lies Instead of Crashing](/blog/when-llm-output-lies-instead-of-crashing/) : another failure class that returns success while being wrong
+- [Two False-Positive Fixes, Same Root Cause](/blog/two-false-positive-fixes-same-root-cause/) : checks that pass for the wrong reason
+- [Verify the System Map Against Live Infra](https://startaitools.com/posts/verify-system-map-against-live-infra/) : measuring reality instead of trusting the document

--- a/marketplace/src/content/blog-posts/making-fire-and-forget-capture-safe-under-failure.md
+++ b/marketplace/src/content/blog-posts/making-fire-and-forget-capture-safe-under-failure.md
@@ -157,9 +157,9 @@ A best-effort, fire-and-forget writer is a distributed system wearing a convenie
 
 ## Related Posts
 
-- [Adversarial Review: The Six Lenses That Halted a Rollout](/posts/adversarial-review-before-team-rollout/) — the governance review that gated this same team-brain rollout.
-- [Every Safety Gate Has a Failure Direction](/posts/every-safety-gate-has-a-failure-direction/) — why drop-on-4xx / keep-on-5xx is a direction choice, not a detail.
-- [Liveness Without Health Is Theater](/posts/liveness-without-health-is-theater/) — the sibling lesson for unattended systems: running is not the same as working.
+- [Adversarial Review: The Six Lenses That Halted a Rollout](/blog/adversarial-review-before-team-rollout/) — the governance review that gated this same team-brain rollout.
+- [Every Safety Gate Has a Failure Direction](/blog/every-safety-gate-has-a-failure-direction/) — why drop-on-4xx / keep-on-5xx is a direction choice, not a detail.
+- [Liveness Without Health Is Theater](/blog/liveness-without-health-is-theater/) — the sibling lesson for unattended systems: running is not the same as working.
 
 <script type="application/ld+json">
 {

--- a/marketplace/src/content/blog-posts/noise-robust-signed-llm-judge-evals.md
+++ b/marketplace/src/content/blog-posts/noise-robust-signed-llm-judge-evals.md
@@ -291,9 +291,9 @@ Same day, a separate estate-hygiene artifact landed in intent-os: a hand-maintai
 
 ## Related posts
 
-- [Eval-gated model swaps: shipping gpt-5.4 as a one-line config switch](/posts/eval-gated-model-swap-gpt-5-4/)
-- [The moat is the trust layer: enforced egress, code-enforced citations, tamper-evident audit](/posts/the-moat-is-the-trust-layer-nexus-byok-rag/)
-- [Every safety gate has a failure direction](/posts/every-safety-gate-has-a-failure-direction/)
+- [Eval-gated model swaps: shipping gpt-5.4 as a one-line config switch](/blog/eval-gated-model-swap-gpt-5-4/)
+- [The moat is the trust layer: enforced egress, code-enforced citations, tamper-evident audit](/blog/the-moat-is-the-trust-layer-nexus-byok-rag/)
+- [Every safety gate has a failure direction](/blog/every-safety-gate-has-a-failure-direction/)
 
 <script type="application/ld+json">
 {

--- a/marketplace/src/content/blog-posts/now-lms-2-0-and-the-email-cutover.md
+++ b/marketplace/src/content/blog-posts/now-lms-2-0-and-the-email-cutover.md
@@ -41,6 +41,6 @@ On the infrastructure side, the MXroute migration of intentsolutions.io is under
 
 ## Related posts
 
-- [Temporary Is Not a Plan](/posts/temporary-is-not-a-plan/)
-- [Do Not Blindly Restart](/posts/do-not-blindly-restart/)
-- [Wrong Mode: Green Is Not a Gate](/posts/wrong-mode-green-is-not-a-gate/)
+- [Temporary Is Not a Plan](/blog/temporary-is-not-a-plan/)
+- [Do Not Blindly Restart](/blog/do-not-blindly-restart/)
+- [Wrong Mode: Green Is Not a Gate](/blog/wrong-mode-green-is-not-a-gate/)

--- a/marketplace/src/content/blog-posts/passing-is-not-validating.md
+++ b/marketplace/src/content/blog-posts/passing-is-not-validating.md
@@ -185,5 +185,5 @@ Mission Control operator kit built, proven, and wired.
 
 ## Related Posts
 
-- [A Green Recovery Drill Can Still Be Lying](/posts/a-green-recovery-drill-can-still-be-lying/)
-- [Let the Model Judge, Make the Code Decide](/posts/let-the-model-judge-make-the-code-decide/)
+- [A Green Recovery Drill Can Still Be Lying](/blog/a-green-recovery-drill-can-still-be-lying/)
+- [Let the Model Judge, Make the Code Decide](/blog/let-the-model-judge-make-the-code-decide/)

--- a/marketplace/src/content/blog-posts/producer-fallback-when-claude-hits-weekly-limit.md
+++ b/marketplace/src/content/blog-posts/producer-fallback-when-claude-hits-weekly-limit.md
@@ -60,7 +60,7 @@ Env knobs:
 
 While Claude was dark, the 2026-07-14 post was produced manually under the same land contract:
 
-- [Exit 0 Is Not Success: Automation Assurance That Verifies Outcomes](/posts/exit-0-is-not-success/)
+- [Exit 0 Is Not Success: Automation Assurance That Verifies Outcomes](/blog/exit-0-is-not-success/)
 - Voice lint PASS, Hugo PASS, dual-publish to tonsofskills + field-notes, live liveness OK
 - Ezekiel packet re-sent with real social copy after the first send degraded (voice-gen still hits Claude)
 
@@ -84,6 +84,6 @@ Tomorrow's 04:00 run can try Claude, fall back to Grok, and still land. That is 
 
 ## Related Posts
 
-- [Exit 0 Is Not Success: Automation Assurance That Verifies Outcomes](/posts/exit-0-is-not-success/)
-- [Liveness Without Health Is Theater](/posts/liveness-without-health-is-theater/)
-- [Empty Is Not Clean: Five Fail-Open Bugs in an AI Agent](/posts/empty-is-not-clean/)
+- [Exit 0 Is Not Success: Automation Assurance That Verifies Outcomes](/blog/exit-0-is-not-success/)
+- [Liveness Without Health Is Theater](/blog/liveness-without-health-is-theater/)
+- [Empty Is Not Clean: Five Fail-Open Bugs in an AI Agent](/blog/empty-is-not-clean/)

--- a/marketplace/src/content/blog-posts/relevance-score-broke-cite-or-refuse-gate.md
+++ b/marketplace/src/content/blog-posts/relevance-score-broke-cite-or-refuse-gate.md
@@ -82,7 +82,7 @@ The eval pipeline now injects a temp ledger at construction instead of opening t
 
 The audit had flagged coverage sitting at 75%. So you add more tests. The reflex is always: more tests → more safety. But coverage alone wouldn't have caught this. The assertion that caught the -1.83 worked because it checked an *invariant* — every score in [0,1] — not because it closed a percentage. The bug wasn't in an untested code path; it was in an *assumption* the tests themselves were making: that the third-party library would always hand back scores in [0,1].
 
-This is why the PR added a real [mutation-testing gate](/posts/coverage-vs-mutation-testing-rules-engine/) (mutmut) that can *fail* the build. Coverage can lie: a covered line is not necessarily a tested line. A mutation-testing gate asks: if we flip a boolean, change an operator, or delete a statement, does the test still pass? If the test passes after the mutation, the test isn't actually testing that line.
+This is why the PR added a real [mutation-testing gate](/blog/coverage-vs-mutation-testing-rules-engine/) (mutmut) that can *fail* the build. Coverage can lie: a covered line is not necessarily a tested line. A mutation-testing gate asks: if we flip a boolean, change an operator, or delete a statement, does the test still pass? If the test passes after the mutation, the test isn't actually testing that line.
 
 The mutation scope was deliberately narrow: pure-logic modules (the citation_verifier itself). String-heavy modules (policy.py regexes, ledger.py hash-chain) are covered by boundary and tamper tests instead, which are stronger than mutmut for string-heavy code. The insight is that mutation testing is best reserved for decision logic—branches, comparisons, threshold checks—where a flipped sign can silently change behavior.
 
@@ -155,7 +155,7 @@ Property tests on the redaction and ledger layers held across every generated in
 
 ## In Context
 
-This post is a sibling to yesterday's [The Moat Is the Trust Layer](/posts/the-moat-is-the-trust-layer-nexus-byok-rag/)—the architecture of the cite-or-refuse gate itself. Today's bug is what you find when you harden that architecture: an assumption buried in the third-party library, silently corrupting the thing you built to defend.
+This post is a sibling to yesterday's [The Moat Is the Trust Layer](/blog/the-moat-is-the-trust-layer-nexus-byok-rag/)—the architecture of the cite-or-refuse gate itself. Today's bug is what you find when you harden that architecture: an assumption buried in the third-party library, silently corrupting the thing you built to defend.
 
 The testing-remediation series moved coverage from 75% → 80%, landing 216 unit tests. But the *real* gains weren't percentage points; they were finding this bug, hardening the redaction and ledger properties against generated inputs, and making the safety invariant executable.
 
@@ -167,9 +167,9 @@ The testing-remediation series moved coverage from 75% → 80%, landing 216 unit
 
 ## Related
 
-- [The Moat Is the Trust Layer](/posts/the-moat-is-the-trust-layer-nexus-byok-rag/) — Architecture of the cite-or-refuse safety gate
-- [Coverage vs. Mutation Testing: Rules Engine Edition](/posts/coverage-vs-mutation-testing-rules-engine/) — Why coverage gaps can hide logic bugs
-- [Gate the Statement, Not the Tool Name](/posts/gate-the-statement-not-the-tool-name/) — Enforcement design and trust boundaries
+- [The Moat Is the Trust Layer](/blog/the-moat-is-the-trust-layer-nexus-byok-rag/) — Architecture of the cite-or-refuse safety gate
+- [Coverage vs. Mutation Testing: Rules Engine Edition](/blog/coverage-vs-mutation-testing-rules-engine/) — Why coverage gaps can hide logic bugs
+- [Gate the Statement, Not the Tool Name](/blog/gate-the-statement-not-the-tool-name/) — Enforcement design and trust boundaries
 
 <script type="application/ld+json">
 {

--- a/marketplace/src/content/blog-posts/splitting-privileges-at-the-ci-boundary.md
+++ b/marketplace/src/content/blog-posts/splitting-privileges-at-the-ci-boundary.md
@@ -43,6 +43,6 @@ The pattern across three repos on one day: fork CI (trust boundary), reconciliat
 
 ## Related Posts
 
-- [Wrong Mode Green is Not a Gate](/posts/wrong-mode-green-is-not-a-gate/)
-- [Temporary is Not a Plan](/posts/temporary-is-not-a-plan/)
-- [Passing is Not Validating](/posts/passing-is-not-validating/)
+- [Wrong Mode Green is Not a Gate](/blog/wrong-mode-green-is-not-a-gate/)
+- [Temporary is Not a Plan](/blog/temporary-is-not-a-plan/)
+- [Passing is Not Validating](/blog/passing-is-not-validating/)

--- a/marketplace/src/content/blog-posts/stop-crying-wolf-3-strike-uptime-monitor-gate.md
+++ b/marketplace/src/content/blog-posts/stop-crying-wolf-3-strike-uptime-monitor-gate.md
@@ -59,6 +59,6 @@ Phase 2–5 hardening (off-prem probe, frontend + TLS-expiry checks, final publi
 
 ## Related Posts
 
-- [Self-Expiring Report-Only CI Gates: From Advisory to Enforced](/posts/self-expiring-report-only-ci-gates/)
-- [Nine Days Silent: When the Blog's Own Pipeline Stopped Publishing Itself](/posts/the-automation-that-stopped-publishing-itself/)
-- [Five Silent Failures in One Day](/posts/five-silent-failures-one-day/)
+- [Self-Expiring Report-Only CI Gates: From Advisory to Enforced](/blog/self-expiring-report-only-ci-gates/)
+- [Nine Days Silent: When the Blog's Own Pipeline Stopped Publishing Itself](/blog/the-automation-that-stopped-publishing-itself/)
+- [Five Silent Failures in One Day](/blog/five-silent-failures-one-day/)

--- a/marketplace/src/content/blog-posts/temporary-is-not-a-plan.md
+++ b/marketplace/src/content/blog-posts/temporary-is-not-a-plan.md
@@ -24,7 +24,7 @@ NOW-LMS (`bmosoluciones/now-lms`, Apache-2.0, Flask and Babel) ships all of it. 
 
 The record also names the costs honestly, because "adopt" is not free:
 
-- You inherit someone else's architecture and someone else's bugs, which is [the supply chain problem](/posts/software-supply-chain-security/) wearing a different hat. Seven deployment bugs surfaced getting it live.
+- You inherit someone else's architecture and someone else's bugs, which is [the supply chain problem](https://startaitools.com/posts/software-supply-chain-security/) wearing a different hat. Seven deployment bugs surfaced getting it live.
 - NOW-LMS is Spanish-first. The English catalog is empty.
 - Single-maintainer bus factor.
 - Customization discipline is mandatory, because deep custom behavior is a merge tax forever.
@@ -33,7 +33,7 @@ The bugs are the visible cost. They are not the real risk. The real risk is that
 
 ## Seven bugs, none of them fork-local
 
-Between 10:43 and 12:46 the deployment bugs got root-caused, five of the seven paired with a named regression test. The test is not ceremony. It is what makes the fix legible to a maintainer who has no reason to trust a stranger's diff, and it is the difference between a fix and [a green check that gates nothing](/posts/when-green-ci-proves-nothing/):
+Between 10:43 and 12:46 the deployment bugs got root-caused, five of the seven paired with a named regression test. The test is not ceremony. It is what makes the fix legible to a maintainer who has no reason to trust a stranger's diff, and it is the difference between a fix and [a green check that gates nothing](/blog/when-green-ci-proves-nothing/):
 
 | Fix | Root cause |
 |---|---|
@@ -198,6 +198,6 @@ Classify it when it is small, or accept that you now own an LMS.
 
 ## Related Posts
 
-- [Copying Files Is Not Installing](/posts/copying-files-is-not-installing/)
-- [Passing Is Not Validating: A Green Check With No Teeth](/posts/passing-is-not-validating/)
-- [Every Safety Gate Has a Failure Direction](/posts/every-safety-gate-has-a-failure-direction/)
+- [Copying Files Is Not Installing](/blog/copying-files-is-not-installing/)
+- [Passing Is Not Validating: A Green Check With No Teeth](/blog/passing-is-not-validating/)
+- [Every Safety Gate Has a Failure Direction](/blog/every-safety-gate-has-a-failure-direction/)

--- a/marketplace/src/content/blog-posts/the-api-is-the-real-boundary.md
+++ b/marketplace/src/content/blog-posts/the-api-is-the-real-boundary.md
@@ -107,7 +107,7 @@ A member can bypass the client gate by hand-crafting an HTTP request. They canno
 
 This is the obvious approach, and it's worth naming exactly why it's wrong rather than waving at it. If you only gate the MCP client — register write tools for admins, hide them from members — you've shipped a system where security depends on every member using the official install and never reaching past it. The model is constrained, sure. But the model is not the attacker. The user behind the model is, and the user can talk to the API any way they like.
 
-The MCP client is not the security boundary. The API is. Every credential the client holds, the user holds. Every endpoint the client calls, the user can call. The instant you treat "the tool isn't registered" as an access control, you've moved the enforcement to the one layer the user fully controls. Client gating with no server gate is theater. Server gating with no client gate works but shows members dead buttons. You want both, and you have to know which one is [load-bearing](/posts/honor-the-gate-when-the-verdict-is-inconvenient/).
+The MCP client is not the security boundary. The API is. Every credential the client holds, the user holds. Every endpoint the client calls, the user can call. The instant you treat "the tool isn't registered" as an access control, you've moved the enforcement to the one layer the user fully controls. Client gating with no server gate is theater. Server gating with no client gate works but shows members dead buttons. You want both, and you have to know which one is [load-bearing](/blog/honor-the-gate-when-the-verdict-is-inconvenient/).
 
 ## Audit: the access log is not the governance trail
 
@@ -155,6 +155,6 @@ The legacy single-key fallback stays for back-compat: an existing `TEAMKB_API_KE
 
 **Related posts:**
 
-- [Green CI Proves Nothing: Why Your Tests Gate Zero Calls](/posts/when-green-ci-proves-nothing/)
-- [Honor the Gate When the Verdict Is Inconvenient](/posts/honor-the-gate-when-the-verdict-is-inconvenient/)
-- [When --cap-drop ALL Broke the Gate Socket](/posts/cap-drop-all-broke-the-gate-socket/)
+- [Green CI Proves Nothing: Why Your Tests Gate Zero Calls](/blog/when-green-ci-proves-nothing/)
+- [Honor the Gate When the Verdict Is Inconvenient](/blog/honor-the-gate-when-the-verdict-is-inconvenient/)
+- [When --cap-drop ALL Broke the Gate Socket](/blog/cap-drop-all-broke-the-gate-socket/)

--- a/marketplace/src/content/blog-posts/the-automation-that-stopped-publishing-itself.md
+++ b/marketplace/src/content/blog-posts/the-automation-that-stopped-publishing-itself.md
@@ -77,6 +77,6 @@ The real lesson: monitoring silence is worse than monitoring noise. Nine days of
 
 ## Related Posts
 
-- [Five Tags, Zero Ships: How an Auto-Release Workflow Lied for a Whole Day](/posts/five-tags-zero-ships/)
-- [Five Silent Failures in One Day](/posts/five-silent-failures-one-day/)
-- [Ship Dormant, Wire Later — A Multi-Agent Slack Production Day](/posts/ship-dormant-wire-later-multi-agent-slack/)
+- [Five Tags, Zero Ships: How an Auto-Release Workflow Lied for a Whole Day](https://startaitools.com/posts/five-tags-zero-ships/)
+- [Five Silent Failures in One Day](/blog/five-silent-failures-one-day/)
+- [Ship Dormant, Wire Later — A Multi-Agent Slack Production Day](https://startaitools.com/posts/ship-dormant-wire-later-multi-agent-slack/)

--- a/marketplace/src/content/blog-posts/the-kernel-must-not-import-its-agents.md
+++ b/marketplace/src/content/blog-posts/the-kernel-must-not-import-its-agents.md
@@ -36,7 +36,7 @@ Before the extraction, the watcher lived inside AGP. After it, AGP has zero know
 
 The boundary has two halves, and they are not the same rule. The headline half is the thesis: **the kernel imports nothing from the leaf** — it does not know the agents that compose it exist. The mirror half constrains the leaf: **the leaf may import only the kernel's frozen contracts, never the daemon's internals** — where "the daemon" is the kernel's live governance loop (`runMediated()`) and the machinery around it. The composed agent composes the contracts the kernel publishes; it never reaches past them into implementation.
 
-Put together, the two halves define one edge: it runs from agent (leaf) to kernel, touches only the published surface, and never runs the other way. A governance kernel that imports the agents it governs breaks the acyclic-dependency rule — it is a governance kernel you cannot reason about. You can no longer point at it and say "this small thing decides and records; here is its trust boundary" — because its [trust boundary](/posts/govern-at-merge-untrusted-union/) now includes every agent that ever leaked into it.
+Put together, the two halves define one edge: it runs from agent (leaf) to kernel, touches only the published surface, and never runs the other way. A governance kernel that imports the agents it governs breaks the acyclic-dependency rule — it is a governance kernel you cannot reason about. You can no longer point at it and say "this small thing decides and records; here is its trust boundary" — because its [trust boundary](https://startaitools.com/posts/govern-at-merge-untrusted-union/) now includes every agent that ever leaked into it.
 
 So the extraction had two acceptance tests, both structural:
 
@@ -122,7 +122,7 @@ You cannot smuggle a change like this through as a patch. The whole value of the
 
 Here is the detail worth teaching, because it is the one that bites. The watcher was not a dormant module. It was **running in production** on a cron: `~/bin/intendants-release-watch.sh`, firing on a schedule, in a governed loop, on a real repo.
 
-Extracting a *running* component is a live-migration problem, not a code move. If you merge the kernel PR that removes `agp watch` while production cron still calls `agp watch`, you have — for however long it takes to notice — a production job pointed at [a command that no longer exists](/posts/every-safety-gate-has-a-failure-direction/).
+Extracting a *running* component is a live-migration problem, not a code move. If you merge the kernel PR that removes `agp watch` while production cron still calls `agp watch`, you have — for however long it takes to notice — a production job pointed at [a command that no longer exists](/blog/every-safety-gate-has-a-failure-direction/).
 
 So the order was inverted deliberately:
 

--- a/marketplace/src/content/blog-posts/the-moat-is-the-trust-layer-nexus-byok-rag.md
+++ b/marketplace/src/content/blog-posts/the-moat-is-the-trust-layer-nexus-byok-rag.md
@@ -109,7 +109,7 @@ Those relevance scores used to be fake. The old code assigned a positional place
 
 ### 3. The tamper-evident ledger: provenance you can verify
 
-A privacy receipt you can edit is a receipt for nothing. P4a added an append-only SQLite audit chain — the same [hash-chained pattern](https://www.schneier.com/academic/archives/1998/01/cryptographic_suppor.html) used across [Intent Solutions](/about/) ledgers — so every operation links to the one before it and the chain can be walked and verified.
+A privacy receipt you can edit is a receipt for nothing. P4a added an append-only SQLite audit chain — the same [hash-chained pattern](https://www.schneier.com/academic/archives/1998/01/cryptographic_suppor.html) used across [Intent Solutions](https://startaitools.com/about/) ledgers — so every operation links to the one before it and the chain can be walked and verified.
 
 The subtle part is not "hash each row." It is *how* you serialize a row into the bytes you hash. The first cut used a bare `"|".join(...)` of the fields, and adversarial review flagged it as a re-attribution attack:
 
@@ -190,7 +190,7 @@ for case in applicable:
 
 Once the corpus exceeds `k` and the answer is placed at position > k with topical distractors around it, `recall` can only reach `1.0` if the retriever *ranks* the relevant doc into the top three. A broken retriever now scores below `1.0`. The metric became a measurement the moment the corpus stopped being small enough to make it trivial.
 
-**groundedness turned a fully-broken pipeline into a PASS.** It skipped-on-error — an exception during evaluation counted as success. So a pipeline that crashed on every case scored a clean groundedness pass. The fix inverts the default: exceptions now score `0.0`; only a genuinely-empty applicable set is allowed to pass. Skip-on-error is the single most common way [an eval lies instead of crashing](/when-llm-output-lies-instead-of-crashing/), because failure and "nothing to evaluate" look identical if you are not careful, and the lazy default treats both as fine.
+**groundedness turned a fully-broken pipeline into a PASS.** It skipped-on-error — an exception during evaluation counted as success. So a pipeline that crashed on every case scored a clean groundedness pass. The fix inverts the default: exceptions now score `0.0`; only a genuinely-empty applicable set is allowed to pass. Skip-on-error is the single most common way [an eval lies instead of crashing](/blog/when-llm-output-lies-instead-of-crashing/), because failure and "nothing to evaluate" look identical if you are not careful, and the lazy default treats both as fine.
 
 **the injection scrubber was corrupting legitimate document prose.** The scrubber that is supposed to strip injection payloads was matching benign phrases — "reply with", "you are now a…" — with greedy end-of-line tails, mangling real retrieved text. In one case it consumed an adjacent secret while chewing through a normal sentence. The fix: match *only* the imperative override phrase, no EOL consumption, and gate the role/word variants on specific cues. A benign-prose regression test now guards against the scrubber deciding that ordinary writing is an attack.
 
@@ -260,6 +260,6 @@ Two secondary repos had minor activity on 2026-07-04. `intent-os` took a beads-b
 
 ## Related posts
 
-- [BM25 Before Vectors: An Eval-Gated Retrieval ADR](/bm25-before-vectors-retrieval-backend-adr/) — the deeper dive on NEXUS's P3 retrieval decision, including why the hybrid `qmd` backend exists and how the eval gate drove the call.
-- [When LLM Output Lies Instead of Crashing](/when-llm-output-lies-instead-of-crashing/) — the exact failure mode the code-enforced refusal and the groundedness gate exist to catch: output that looks fine while the pipeline underneath is broken.
-- [Shipping gpt-5.4 as One Config Line](/eval-gated-model-swap-gpt-5-4/) — the same eval-gated-change discipline applied to a model swap, where the gate is what lets a provider change be a one-line diff instead of a leap of faith.
+- [BM25 Before Vectors: An Eval-Gated Retrieval ADR](https://startaitools.com/posts/bm25-before-vectors-retrieval-backend-adr/) — the deeper dive on NEXUS's P3 retrieval decision, including why the hybrid `qmd` backend exists and how the eval gate drove the call.
+- [When LLM Output Lies Instead of Crashing](/blog/when-llm-output-lies-instead-of-crashing/) — the exact failure mode the code-enforced refusal and the groundedness gate exist to catch: output that looks fine while the pipeline underneath is broken.
+- [Shipping gpt-5.4 as One Config Line](/blog/eval-gated-model-swap-gpt-5-4/) — the same eval-gated-change discipline applied to a model swap, where the gate is what lets a provider change be a one-line diff instead of a leap of faith.

--- a/marketplace/src/content/blog-posts/the-wrong-product-built-perfectly.md
+++ b/marketplace/src/content/blog-posts/the-wrong-product-built-perfectly.md
@@ -130,7 +130,7 @@ Every expensive, durable thing survived untouched. The deploy key didn't care th
 
 This is the structural point, and it's the reason the post exists.
 
-The error lived at the requirements layer. The pipeline below it was faithful — and faithful is exactly the problem. A high-quality pipeline does not catch a misread spec. It executes the misread perfectly and hands you the wrong thing at production grade. We've watched the same shape from a different angle — [a React app whose container shipped the Vite dev server to every visitor](/posts/vite-dev-server-in-production-the-871-byte-tell/), green health checks and all. Every downstream step compounded the original reading: the plan assumed an audience, the IA sorted that audience, the schema described that audience, the deploy shipped it to that audience. Each step was correct relative to the one above it, and the one at the very top was wrong.
+The error lived at the requirements layer. The pipeline below it was faithful — and faithful is exactly the problem. A high-quality pipeline does not catch a misread spec. It executes the misread perfectly and hands you the wrong thing at production grade. We've watched the same shape from a different angle — [a React app whose container shipped the Vite dev server to every visitor](/blog/vite-dev-server-in-production-the-871-byte-tell/), green health checks and all. Every downstream step compounded the original reading: the plan assumed an audience, the IA sorted that audience, the schema described that audience, the deploy shipped it to that audience. Each step was correct relative to the one above it, and the one at the very top was wrong.
 
 The five declined design subagents are the tell. People reach for "more process at the execution layer" as the fix for shipping the wrong thing. It isn't. Those five subagents would have made the *audience* version more beautiful — better triage copy, tighter property cards, a more polished FAQ. They would have polished the wrong product. Spending more at the execution layer when the defect is at the requirements layer just buys you a higher-fidelity mistake.
 
@@ -163,9 +163,9 @@ And don't draw the wrong conclusion about the five design subagents we declined 
 
 ## Related posts
 
-- [The Vite Dev Server in Production: The 871-Byte Tell](/posts/vite-dev-server-in-production-the-871-byte-tell/) — another story of shipping the wrong thing to production cleanly, and the small artifact that finally gave it away.
-- [Server-Ops MCP: Safety Before Tools](/posts/server-ops-mcp-safety-before-tools/) — the same instinct as the force-command deploy key: constrain the blast radius before you hand anything the keys.
-- [Self-Expiring, Report-Only CI Gates](/posts/self-expiring-report-only-ci-gates/) — on putting process spend where it actually pays instead of where it feels productive.
+- [The Vite Dev Server in Production: The 871-Byte Tell](/blog/vite-dev-server-in-production-the-871-byte-tell/) — another story of shipping the wrong thing to production cleanly, and the small artifact that finally gave it away.
+- [Server-Ops MCP: Safety Before Tools](/blog/server-ops-mcp-safety-before-tools/) — the same instinct as the force-command deploy key: constrain the blast radius before you hand anything the keys.
+- [Self-Expiring, Report-Only CI Gates](/blog/self-expiring-report-only-ci-gates/) — on putting process spend where it actually pays instead of where it feels productive.
 
 <script type="application/ld+json">
 {

--- a/marketplace/src/content/blog-posts/when-green-ci-proves-nothing.md
+++ b/marketplace/src/content/blog-posts/when-green-ci-proves-nothing.md
@@ -87,13 +87,13 @@ jobs:
 
 **The transferable lesson:** an integration test that exercises zero of the thing under test is worse than a red one, because that fake-green reads as "covered" when it covered nothing. The fix is not "trust the green." It is to assert that the test did the work. For a governance gate, that assertion is `gated_count > 0`. A green check is a claim. The evidence bundle is the proof. This generalizes everywhere: any test whose green can be reached without exercising the property it claims should fail closed when the property was not exercised.
 
-Also shipped: the sprite→intendant rename (ADR 038). Fly.io ships "Sprites" at sprites.dev—stateful sandboxes for AI agents with Claude Code as an explicit use case. A direct product/lane collision. "Intendant" is the agent-noun of Latin *intendere*, the root of *intent*, "one who executes on behalf of an authority." And the cross-repo echo: CCSC (AGP's substrate) shipped a "footgun-inversion" regression-test epic the same week, pinning fail-closed defaults (session isolation, "every policy decision is journaled—no gaps"). The same move as the no-fake-green guard: prove the safety property holds rather than trust it. This echoes the principle we follow in [honoring the gate when the verdict is inconvenient](/posts/honor-the-gate-when-the-verdict-is-inconvenient/) — the gate is only as good as your commitment to enforcing it even when it blocks your path.
+Also shipped: the sprite→intendant rename (ADR 038). Fly.io ships "Sprites" at sprites.dev—stateful sandboxes for AI agents with Claude Code as an explicit use case. A direct product/lane collision. "Intendant" is the agent-noun of Latin *intendere*, the root of *intent*, "one who executes on behalf of an authority." And the cross-repo echo: CCSC (AGP's substrate) shipped a "footgun-inversion" regression-test epic the same week, pinning fail-closed defaults (session isolation, "every policy decision is journaled—no gaps"). The same move as the no-fake-green guard: prove the safety property holds rather than trust it. This echoes the principle we follow in [honoring the gate when the verdict is inconvenient](/blog/honor-the-gate-when-the-verdict-is-inconvenient/) — the gate is only as good as your commitment to enforcing it even when it blocks your path.
 
 **Related Posts:**
 
-- [Honor the Gate When the Verdict Is Inconvenient](/posts/honor-the-gate-when-the-verdict-is-inconvenient/)
-- [The Two Postgres Bugs the Tests Caught: A Real-DB Integration Test Case Study](/posts/postgres-approval-sink-bugs-the-tests-caught/)
-- [Human-in-the-Loop Is a Delivery Guarantee, Not a UI Feature](/posts/hitl-delivery-is-a-fail-closed-exactly-once-problem/)
+- [Honor the Gate When the Verdict Is Inconvenient](/blog/honor-the-gate-when-the-verdict-is-inconvenient/)
+- [The Two Postgres Bugs the Tests Caught: A Real-DB Integration Test Case Study](/blog/postgres-approval-sink-bugs-the-tests-caught/)
+- [Human-in-the-Loop Is a Delivery Guarantee, Not a UI Feature](/blog/hitl-delivery-is-a-fail-closed-exactly-once-problem/)
 
 <script type="application/ld+json">
 {

--- a/marketplace/src/content/blog-posts/when-llm-output-lies-instead-of-crashing.md
+++ b/marketplace/src/content/blog-posts/when-llm-output-lies-instead-of-crashing.md
@@ -57,6 +57,6 @@ Also shipped: version-coupling hygiene across `@intentsolutions/core`. Adopted `
 
 ## Related Posts
 
-- [The LLM Should Never Do the Math](/posts/llm-never-does-the-math/) — The SQL-first architecture that backs this fix.
-- [CodeQL Caught the Race I Dismissed](/posts/codeql-caught-the-race-i-dismissed/) — Another review tool catching a bug the author had waved off; same shape as Gemini catching the silent lie.
-- [MCP Server Auth: The API Is the Real Boundary](/posts/the-api-is-the-real-boundary/) — The boundary-discipline theme, one layer down the stack.
+- [The LLM Should Never Do the Math](https://startaitools.com/posts/llm-never-does-the-math/) — The SQL-first architecture that backs this fix.
+- [CodeQL Caught the Race I Dismissed](https://startaitools.com/posts/codeql-caught-the-race-i-dismissed/) — Another review tool catching a bug the author had waved off; same shape as Gemini catching the silent lie.
+- [MCP Server Auth: The API Is the Real Boundary](/blog/the-api-is-the-real-boundary/) — The boundary-discipline theme, one layer down the stack.

--- a/marketplace/src/content/blog-posts/wrong-mode-green-is-not-a-gate.md
+++ b/marketplace/src/content/blog-posts/wrong-mode-green-is-not-a-gate.md
@@ -53,7 +53,7 @@ scripts/extract-marketplace-catalog-projection.py --check --surface plugin-marke
 
 Verified, not assumed: `check-surface-registry.py` returned exit 0 on a registry with the wrong mode. So did the test suite. Both only asked "does this script exist?"
 
-That is [exit 0 is not success](/posts/exit-0-is-not-success/) wearing a freshness costume. It is also the failure mode described in [every safety gate has a failure direction](/posts/every-safety-gate-has-a-failure-direction/): the next person who flips a surface, sees red, and "fixes" the flag gets a quieter green. No gate objects. The lane dies because people learn not to read it.
+That is [exit 0 is not success](/blog/exit-0-is-not-success/) wearing a freshness costume. It is also the failure mode described in [every safety gate has a failure direction](/blog/every-safety-gate-has-a-failure-direction/): the next person who flips a surface, sees red, and "fixes" the flag gets a quieter green. No gate objects. The lane dies because people learn not to read it.
 
 ### Fix: pin mode, not only path
 
@@ -110,7 +110,7 @@ Fix was one shared rule (`captured_source.clause_end`): period-digit is not clau
 
 Plus a gap the review surfaced in its own evidence: nothing verified that `vendor-meta.json` describes the bytes on disk. `--check` proves the projection derives from files and never reads sha256. A hand re-vendor with a wrong hash passed every gate. New `scripts/check-vendor-meta-integrity.py` checks existence, sha256, byte count, and undeclared files. Demonstrated: corrupt a recorded sha and the new gate fails while `--check` still prints OK.
 
-That is the same family as [empty is not clean](/posts/empty-is-not-clean/) and [passing is not validating](/posts/passing-is-not-validating/): a check that never looks at the claim under audit.
+That is the same family as [empty is not clean](/blog/empty-is-not-clean/) and [passing is not validating](/blog/passing-is-not-validating/): a check that never looks at the claim under audit.
 
 ## Neighbor defect: the bot restored the human baseline
 
@@ -179,7 +179,7 @@ Session signal for the day was strong across Claude Opus 4.8, Grok 4.5, and GPT-
 
 The interesting collaboration fact is not token volume. It is the gap the review filled. With AI review dark on the lab, Claude Opus 4.8 and Grok 4.5 spent the day implementing and chasing CI. The nine defects came from a deliberate hostile re-read of a commit that had already gone green under mutation tests. Tools did not invent that pass. An operator ordered it because the automated second pair of eyes was gone.
 
-That is the same discipline as [adversarial review before team rollout](/posts/adversarial-review-before-team-rollout/), applied inward to a gate that ships under your own name.
+That is the same discipline as [adversarial review before team rollout](/blog/adversarial-review-before-team-rollout/), applied inward to a gate that ships under your own name.
 
 ## Also shipped
 
@@ -206,10 +206,10 @@ Wrong-mode green is not a gate. It is a board that learned to smile.
 
 ## Related posts
 
-- [Exit 0 Is Not Success](/posts/exit-0-is-not-success/)
-- [Every Safety Gate Has a Failure Direction](/posts/every-safety-gate-has-a-failure-direction/)
-- [A Green Recovery Drill Can Still Be Lying](/posts/a-green-recovery-drill-can-still-be-lying/)
-- [Passing Is Not Validating](/posts/passing-is-not-validating/)
-- [Empty Is Not Clean](/posts/empty-is-not-clean/)
-- [When Green CI Proves Nothing](/posts/when-green-ci-proves-nothing/)
-- [Adversarial Review Before Team Rollout](/posts/adversarial-review-before-team-rollout/)
+- [Exit 0 Is Not Success](/blog/exit-0-is-not-success/)
+- [Every Safety Gate Has a Failure Direction](/blog/every-safety-gate-has-a-failure-direction/)
+- [A Green Recovery Drill Can Still Be Lying](/blog/a-green-recovery-drill-can-still-be-lying/)
+- [Passing Is Not Validating](/blog/passing-is-not-validating/)
+- [Empty Is Not Clean](/blog/empty-is-not-clean/)
+- [When Green CI Proves Nothing](/blog/when-green-ci-proves-nothing/)
+- [Adversarial Review Before Team Rollout](/blog/adversarial-review-before-team-rollout/)


### PR DESCRIPTION
## What

Repairs **127 links across 34 syndicated blog posts** that resolved to 404s on `tonsofskills.com` — our own domain. Verified live, not inferred.

## Why

Hugo serves posts at `/posts/<slug>/` and startaitools' bodies link that way. This site serves them at `/blog/<slug>/`. The syndication transform carried those links across verbatim, so all of them broke on arrival:

| Count | Shape |
| --- | --- |
| 121 | `](/posts/<slug>/)` — 47 distinct targets |
| 6 | bare Hugo paths — `](/about/)`, `](/irsb-ecosystem/)`, 4 more |

**This is not tidiness.** These sit on the exact pages whose canonical tags were just set to point at startaitools. Telling Google "this is a copy of startaitools" while the copy is full of links into the void is the opposite of the signal that work was for.

**Why it survived:** `check-links.yml` runs lychee on every markdown PR and has been finding these *every week*. Both invocations are configured `fail: false`, so the job reports success regardless — **500 link errors had accumulated behind a green check.** A one-time sweep previously fixed 82 posts (hence the 274 links already using `/blog/`), but the pipeline was never fixed, so drift resumed: every broken post here was syndicated **after** that sweep.

## How it works

Per-target resolution, verified before writing:

| Case | Target | Links |
| --- | --- | --- |
| syndicated here (`<slug>.md` exists) | `/blog/<slug>/` | 108 |
| not syndicated | the startaitools original | 13 |
| bare Hugo paths | hand-resolved, HTTP-verified | 6 |

**Chose conditional over always-cross-domain.** Sending everything to startaitools is also link-correct and simpler, but 38 of 47 targets *are* syndicated here, so it would push readers off this site for no reason.

Every fallback was HTTP-checked **serially** before being written — all 9 unsyndicated `/posts/` targets returned 200, as did `startaitools.com/about/` and `/irsb-ecosystem/` (Hugo top-level pages, absent from this site). Serial because a parallel sweep earlier in this work produced 60 false 404s from rate limiting; **nothing was written on unverified data.**

## Layer touched

Content only — `marketplace/src/content/blog-posts/`. No schema, no route, no build-script change. The `/blog/[...slug].astro` route already serves every internal target (each is a local `.md`).

## Verification & evidence

```
residual ](/posts/ in the corpus ....... 0
diff is provably links-only ............ 123 removed / 123 added, 0 lines whose
                                         non-link prose differs after stripping
                                         link targets from both sides
frontmatter lines changed .............. 0  (no canonical/title/date/tags touched)
markdownlint on the 34 changed files ... 0 errors
5 new internal /blog/ targets checked
  against the live site ................ 200 x5
re-verified AFTER prettier --write ..... still -123/+123, 0 prose changes
```

The last line matters: the pre-commit hook runs `prettier --write` over all 34 files, so the links-only property was re-proved on the **committed** diff, not just my working tree.

## Root cause is fixed separately

The transform itself now resolves these links, so this cannot silently recur: **jeremylongshore/startaitools.com#52** (16/16 tests, mutation-verified — the pre-fix state fails 4 assertions). Without it, this PR would be the *second* corpus sweep undone by the next publish.

## Risk

Low. Content-only; no code path changes. Every written target was HTTP-verified. Worst case is a link pointing cross-domain where an internal one would have served — not a broken one. Rollback is `git revert` of a single content commit.

## Operational impact

None. No deps, env, migrations, or deploy ordering. Route count unchanged (no files added or removed).

## Follow-up & deferred

- **`fail: false` in `.lychee.toml` / `check-links.yml`** — the reason this ran unchecked for weeks. Deliberately **not** in this PR: it was switched off because rate-limits produced ~200 false failures, so flipping it without narrowing the exclude list first just re-breaks every PR. Separate change.
- ~110 external broken links (docs.anthropic.com, apolloio.github.io, openrouter.ai) remain — genuine third-party rot, appropriate for the weekly scheduled report rather than a blocking gate.
- 391 internal `file://` link errors remain, including `SECURITY.md` / `CONTRIBUTING.md` / `CODE_OF_CONDUCT.md` linked at repo root from 12 files while living in `.github/`.

Refs jeremylongshore/startaitools.com#52

- Jeremy Longshore
intentsolutions.io