### PR TITLE
fix(docs-governance): repoint 11 internal doc links that resolve to nothing

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -10,7 +10,7 @@ fully supported versus best-effort.
 | Ask a usage question              | [GitHub Discussions — Q&A](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/discussions/categories/q-a)                     |
 | Propose or discuss an idea        | [GitHub Discussions — Ideas](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/discussions/categories/ideas)                 |
 | Show off something you built      | [GitHub Discussions — Show and tell](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/discussions/categories/show-and-tell) |
-| Request a new plugin pack         | [Plugin Pack Request discussion template](.github/DISCUSSION_TEMPLATE/plugin-pack-request.yml)                                                |
+| Request a new plugin pack         | [Plugin Pack Request discussion template](DISCUSSION_TEMPLATE/plugin-pack-request.yml)                                                        |
 | Report a bug or request a feature | [Open an issue](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/issues/new/choose)                                         |
 | Submit a plugin                   | The plugin-submission issue template, then follow [CONTRIBUTING.md](CONTRIBUTING.md)                                                          |
 | Report a security vulnerability   | [SECURITY.md](SECURITY.md) — **never a public issue**                                                                                         |
@@ -38,8 +38,8 @@ triage SLA above.
 ## What's supported vs best-effort
 
 This repo follows the mirror-by-default model for externally-synced plugins (see
-[STANDARDS.md](STANDARDS.md) and the
-[decision record](000-docs/694-AT-DECR-external-sync-mirror-by-default-model.md)),
+[STANDARDS.md](../STANDARDS.md) and the
+[decision record](../000-docs/694-AT-DECR-external-sync-mirror-by-default-model.md)),
 which determines where a fix can actually land:
 
 - **Intent Solutions–authored plugins and skills** (the large in-repo majority),
@@ -54,7 +54,7 @@ which determines where a fix can actually land:
 
 ## Before you post
 
-- Check [README.md](README.md) and [CONTRIBUTING.md](CONTRIBUTING.md) — most
+- Check [README.md](../README.md) and [CONTRIBUTING.md](CONTRIBUTING.md) — most
   install, catalog, and submission questions are answered there.
 - Search existing issues and discussions; duplicates get closed with a pointer.
 - Interactions in every support channel are governed by the

--- a/000-docs/071-DR-GUID-user-security.md
+++ b/000-docs/071-DR-GUID-user-security.md
@@ -331,8 +331,8 @@ Description:
 ## 🔗 Additional Resources
 
 - **Report Security Issues**: [GitHub Issues](https://github.com/jeremylongshore/claude-code-plugins/issues)
-- **Marketplace Security Policy**: [SECURITY.md](../SECURITY.md)
-- **Plugin Developer Guidelines**: [CONTRIBUTING.md](../CONTRIBUTING.md)
+- **Marketplace Security Policy**: [SECURITY.md](../.github/SECURITY.md)
+- **Plugin Developer Guidelines**: [CONTRIBUTING.md](../.github/CONTRIBUTING.md)
 - **Claude Code Official Docs**: https://docs.claude.com/en/docs/claude-code/security
 
 ---

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -3,7 +3,7 @@
 The live roster for the maintainer ladder. **How the ladder works** (tiers,
 rights, vetting, delegation) is in [`GOVERNANCE.md`](GOVERNANCE.md). This file is
 just _who_ — handles, tiers, and areas. No personal information beyond a public
-GitHub handle; security contact is in [`SECURITY.md`](SECURITY.md).
+GitHub handle; security contact is in [`SECURITY.md`](.github/SECURITY.md).
 
 Tiers: **Contributor · Reviewer · Approver · Maintainer · Lead** (see GOVERNANCE).
 Areas: `ci-infra`, `validator-schema`, `marketplace-site`, `external-sync`,

--- a/STANDARDS.md
+++ b/STANDARDS.md
@@ -73,7 +73,7 @@ blocks a merge. Promotion to a blocking gate is a separate, later cutover step.
 `pnpm run sync-marketplace` regenerates `marketplace.json`, missing
 `plugins/**/package.json` files, and the README AUTO-TOC block. The pre-commit hook
 runs it automatically when the extended catalog is staged, and CI fails if any
-derived file drifts. Authoring workflow: [CONTRIBUTING.md](CONTRIBUTING.md).
+derived file drifts. Authoring workflow: [CONTRIBUTING.md](.github/CONTRIBUTING.md).
 
 ## External plugins: mirror by default
 
@@ -98,5 +98,5 @@ the [decision record](000-docs/694-AT-DECR-external-sync-mirror-by-default-model
 | Required fields, tier model, history | [000-docs/SCHEMA_CHANGELOG.md](000-docs/SCHEMA_CHANGELOG.md)                                                                   |
 | Full skills standard (master spec)   | [000-docs/6767-b-SPEC-DR-STND-claude-skills-standard.md](000-docs/6767-b-SPEC-DR-STND-claude-skills-standard.md)               |
 | External-sync policy                 | [000-docs/694-AT-DECR-external-sync-mirror-by-default-model.md](000-docs/694-AT-DECR-external-sync-mirror-by-default-model.md) |
-| Contribution requirements            | [CONTRIBUTING.md](CONTRIBUTING.md)                                                                                             |
-| Security policy                      | [SECURITY.md](SECURITY.md)                                                                                                     |
+| Contribution requirements            | [CONTRIBUTING.md](.github/CONTRIBUTING.md)                                                                                     |
+| Security policy                      | [SECURITY.md](.github/SECURITY.md)                                                                                             |

--- a/tests/PERSONAS.md
+++ b/tests/PERSONAS.md
@@ -20,7 +20,7 @@ surface area we ship — not in a generic "developer persona" abstraction.
 
 **Role.** External contributor opening a fork-and-PR to add or update a
 plugin or skill. Could be a one-time submitter or a recurring contributor.
-Maps to the workflow described in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
+Maps to the workflow described in [`CONTRIBUTING.md`](../.github/CONTRIBUTING.md).
 
 **Primary goals.**
 
@@ -29,7 +29,7 @@ Maps to the workflow described in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
 - Pass `./scripts/quick-test.sh` locally before pushing so CI doesn't churn.
 - Score above the Intent Solutions 100-point rubric threshold in the
   marketplace-tier validator (`scripts/validate-skills-schema.py
-  --marketplace`).
+--marketplace`).
 - Get actionable feedback fast — Gemini PR review within 2–5 minutes,
   maintainer follow-up within 48 hours.
 - Have the install command published in the README and `/plugins/<slug>/`


### PR DESCRIPTION
## What

Repoints 11 relative markdown links across 5 first-party docs that pointed at paths which do not exist, so they 404 for anyone clicking them on GitHub.

| File | Links | Was |
| --- | --- | --- |
| `.github/SUPPORT.md` | 4 | sibling/parent paths written as if from the repo root |
| `STANDARDS.md` | 3 | `CONTRIBUTING.md`, `SECURITY.md` |
| `000-docs/071-DR-GUID-user-security.md` | 2 | `../SECURITY.md`, `../CONTRIBUTING.md` |
| `MAINTAINERS.md` | 1 | `SECURITY.md` |
| `tests/PERSONAS.md` | 1 | `../CONTRIBUTING.md` |

## Why

One wrong assumption repeated: that the community health files sit at the repo root. They live in `.github/` — which is correct and idiomatic, since GitHub's UI discovers them from there. So the **files** are right and the **links** were wrong.

`.github/SUPPORT.md` had the mirror-image mistake — it wrote paths as if it were at the root, so `README.md` resolved to `.github/README.md` and `.github/DISCUSSION_TEMPLATE/…` resolved to `.github/.github/…`.

**Chose fixing links over moving files** because moving them would break GitHub's automatic discovery of SECURITY / CONTRIBUTING / CODE_OF_CONDUCT — the "Report a vulnerability" button and the contributing prompt on PRs. That's a real regression to fix a cosmetic one.

## How found — and what was deliberately left alone

I resolved every relative link in every git-tracked `.md` against the filesystem. That surfaced **391** file-not-found errors, but only these 11 are ours to fix:

| Count | Class | Action |
| --- | --- | --- |
| 377 | external mirror plugins (dir has `.source.json`) | **Left alone.** Correct in the contributor's own repo, broken only in our mirror. Editing violates the never-clobber rule in CLAUDE.md and the next sync reverts it. Upstreaming is the only correct route. |
| ~40 | `tests/fixtures/**` | Left alone. Deliberately arbitrary content, already excluded in `.lychee.toml`. |
| **11** | **our own docs** | **This PR.** |
| ~8 | code fragments that look like links (`url`, `path`, `[a-z0-9-]*`, `**tc["args"]`) inside fenced examples | Left alone — false positives, not links. |
| ~2 | genuinely missing docs (`vulnerability-report.md`, `docs/examples.md`) | Left alone — a content gap, not a path error. |

So the honest read of "391 broken internal links" is: **11 are defects in our own docs**; the overwhelming majority sit in mirrors we must not touch.

## Layer touched

Documentation only. No code, schema, route, or build-script change.

## Verification & evidence

```
all 11 targets re-resolved against the filesystem ... 0 unresolved
diff is link-target-only ........................... -11 / +11 lines, 0 lines
                                                     whose non-link prose differs
```

The links-only property was proved by stripping every `](…)` target from both sides of each changed line and asserting the remaining prose is byte-identical.

## Risk

Minimal. Docs-only, 11 single-token path edits, each target verified to exist. No behaviour, API, or contract change. Rollback is `git revert` of one commit.

## Operational impact

None — no deps, env, migrations, or deploy ordering.

## Follow-up & deferred

- **`fail: false` in `check-links.yml` / `.lychee.toml`** — the reason all of this ran unchecked for weeks. Needs the exclude list narrowed first: it was switched off because rate-limits produced ~200 false failures, so flipping it back without that just reds every PR.
- Upstreaming frontmatter/link fixes to the 33 mirror sources — respectful-upstream flow per CLAUDE.md (friendly issue first, contributor owns the PR), and any contributor-facing wording needs sign-off before posting.
- The 2 genuinely missing docs.

Refs #1141 (the syndicated-blog half of the same link audit)

- Jeremy Longshore
intentsolutions.io