### PR TITLE
ci(ci-infra): gate internal doc links so dead paths cannot accumulate unnoticed

### DIFF
--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -190,6 +190,15 @@ jobs:
       - name: Validate design-token discipline (DESIGN.md color rules)
         run: node scripts/lint-design-tokens.mjs
 
+      # Deliberately a step in `validate` (already in ci-required's needs) rather
+      # than a new job: it needs no wiring change to become blocking, and it must
+      # NOT be confused with check-links.yml, which is path-filtered and reports
+      # `fail: false`. Only the DETERMINISTIC half (links to paths inside the repo)
+      # is gated here; external link rot stays with the weekly lychee report,
+      # where a rate-limit false positive costs a glance, not a blocked merge.
+      - name: Validate internal doc links resolve (deterministic half of link-check)
+        run: node scripts/check-internal-doc-links.mjs
+
       - name: Validate cascading Greptile configuration
         run: |
           node --test scripts/validate-greptile-config.test.mjs

--- a/scripts/check-internal-doc-links.mjs
+++ b/scripts/check-internal-doc-links.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+/**
+ * check-internal-doc-links.mjs — fail the build when a first-party doc links to
+ * a file that does not exist.
+ *
+ * WHY THIS EXISTS RATHER THAN JUST GATING check-links.yml
+ * ------------------------------------------------------
+ * The repo already runs lychee on every markdown PR, and it has been finding
+ * these every week — 500 errors on the last completed run. Both lychee
+ * invocations are configured `fail: false`, so the job reports success
+ * regardless, and 391 of those 500 were dead links to paths inside this repo.
+ *
+ * Simply flipping lychee to `fail: true` does not work, and the config comment
+ * says why: rate limits and TLS resets produced ~200 false failures. That is the
+ * nature of network checking — it is NON-DETERMINISTIC, so it cannot be a
+ * required check without flaking the merge queue.
+ *
+ * This script gates the half that IS deterministic: links to paths inside the
+ * repo. No network, no rate limits, no flakes — the same input always gives the
+ * same answer, which is the only kind of check that belongs in `ci-required`.
+ * External link rot stays with the weekly lychee report, where a false positive
+ * costs a glance instead of a blocked merge.
+ *
+ * WHAT IS DELIBERATELY NOT COUNTED
+ * --------------------------------
+ * Of the 391 file-not-found errors, only a small minority are defects in our
+ * own docs. Counting the rest would make the gate a liar:
+ *
+ *   - External mirror plugins (their dir carries `.source.json`). These links
+ *     are correct in the contributor's own repo and broken only in our mirror.
+ *     CLAUDE.md's never-clobber rule forbids editing them, and the next sync
+ *     would revert us anyway. Upstreaming is the only correct route, so a gate
+ *     demanding a local fix would demand a rule violation.
+ *   - `skills/.curated/**` — a GENERATED mirror of the best plugin skills. The
+ *     plugin skill is the source of truth; editing the mirror is wrong and
+ *     `promote-curated-check` already guards the pairing.
+ *   - `tests/fixtures/**` — deliberately arbitrary content, already excluded in
+ *     `.lychee.toml`.
+ *   - Anything inside a fenced code block. `](url)`, `](path)` and
+ *     `](references/file.md)` in a usage example are illustrations, not links.
+ *     Counting them would train authors to contort their examples.
+ *
+ * RATCHETING, NOT ZERO
+ * --------------------
+ * Same contract as scripts/lint-design-tokens.mjs: the count may fall, never
+ * rise, and the script REFUSES to raise its own baseline. A zero baseline would
+ * be dishonest today (a handful of genuinely-missing docs remain, which is a
+ * content gap rather than a path typo) and would tempt whoever hits it into
+ * excluding a whole directory to get green.
+ *
+ * Usage:  node scripts/check-internal-doc-links.mjs [--list]
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * Maximum tolerated count. Lower this when links are fixed; the script will not
+ * raise it for you.
+ *
+ * The 1 is a known, single defect, named here so nobody has to re-derive it:
+ *
+ *   plugins/saas-packs/clerk-pack/skills/clerk-core-workflow-b/references/
+ *     session-middleware-deep-dive.md:279
+ *   links to `references/session-middleware-deep-dive.md` — i.e. to ITSELF, from
+ *   inside itself, so it resolves to references/references/... It is a stray copy
+ *   of the pointer in the parent SKILL.md:52 (which is correct).
+ *
+ * Not fixed in the same change that introduced this gate because that file is a
+ * PROMOTED source: `skills/.curated/clerk-core-workflow-b/references/...` is a
+ * byte-identical generated mirror of it, and `promote-curated-check` fails a PR
+ * that edits a promoted source without regenerating. Editing pack prose plus
+ * syncing the curated mirror deserves its own review rather than riding along in
+ * a CI-gate change. Lower this to 0 when that lands.
+ */
+const BASELINE = 1;
+
+/** Links that are illustrations inside fenced code, not navigation. */
+function stripFencedCode(text) {
+  const out = [];
+  let fence = null;
+  for (const line of text.split('\n')) {
+    const m = /^\s*(```+|~~~+)/.exec(line);
+    if (m) {
+      if (fence === null) fence = m[1][0];
+      else if (m[1][0] === fence) fence = null;
+      out.push(''); // keep line numbering intact
+      continue;
+    }
+    out.push(fence === null ? line : '');
+  }
+  // Also blank out INLINE code spans. Skill docs teach link syntax by example —
+  // `[text](path)`, `[[N]](url)`, `[file](references/file.md)` — and every one of
+  // those is an illustration of the syntax, not a link to follow. Counting them
+  // would push authors into contorting their own documentation to appease a gate.
+  return out.join('\n').replace(/`+[^`\n]*`+/g, (m) => ' '.repeat(m.length));
+}
+
+function isExcluded(file) {
+  const parts = file.split('/');
+  if (parts[0] === 'tests' && parts.includes('fixtures')) return true;
+  if (file.startsWith('skills/.curated/')) return true;
+  // External mirror: plugins/<category>/<name>/ containing .source.json
+  if (parts[0] === 'plugins' && parts.length >= 3) {
+    if (existsSync(join(ROOT, parts[0], parts[1], parts[2], '.source.json'))) return true;
+  }
+  return false;
+}
+
+const LINK = /\]\((?!https?:|#|mailto:|tel:|data:)([^)\s#]+)(?:#[^)]*)?\)/g;
+
+function main() {
+  // maxBuffer: the tracked markdown list is >1 MB in this repo, which overflows
+  // execFileSync's 1 MB default and throws with the whole list in the message.
+  const files = execFileSync('git', ['ls-files', '*.md'], {
+    cwd: ROOT,
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+  })
+    .split('\n')
+    .filter(Boolean)
+    .filter((f) => !isExcluded(f));
+
+  const broken = [];
+  for (const file of files) {
+    let text;
+    try {
+      text = readFileSync(join(ROOT, file), 'utf8');
+    } catch {
+      continue; // unreadable is not a link defect
+    }
+    const body = stripFencedCode(text);
+    for (const m of body.matchAll(LINK)) {
+      const target = m[1].trim();
+      // Absolute site paths (/blog/...) are routes, not files — not our business.
+      if (!target || target.startsWith('/')) continue;
+      if (!existsSync(join(ROOT, dirname(file), target))) {
+        broken.push({ file, target });
+      }
+    }
+  }
+
+  const list = process.argv.includes('--list');
+  if (list || broken.length > BASELINE) {
+    for (const b of broken) console.log(`  ${b.file} -> ${b.target}`);
+    if (list) console.log('');
+  }
+
+  console.log(`internal doc links: ${broken.length} unresolved (baseline ${BASELINE})`);
+
+  if (broken.length > BASELINE) {
+    console.error(
+      `\nFAIL: ${broken.length} unresolved internal links exceeds the baseline of ${BASELINE}.\n` +
+        `Fix the link (or the missing file) rather than raising the baseline — this\n` +
+        `script will not raise it, and a rising count is how 391 of these accumulated\n` +
+        `behind a green check in the first place.`,
+    );
+    process.exit(1);
+  }
+  if (broken.length < BASELINE) {
+    console.log(
+      `\n${BASELINE - broken.length} fewer than baseline — lower BASELINE to ${broken.length} ` +
+        `in ${'scripts/check-internal-doc-links.mjs'} to lock the gain in.`,
+    );
+  }
+}
+
+main();


### PR DESCRIPTION
## What

Adds `scripts/check-internal-doc-links.mjs` and runs it as a step in the existing `validate` job, so a PR that adds a link to a nonexistent path inside this repo fails.

## Why

The repo already runs lychee on every markdown PR. It has been finding dead links **every week** — 500 errors on the last completed run — and reporting **success** every time, because both invocations are configured `fail: false`. 391 of those 500 were links to paths inside this repo. #1141 and #1142 just fixed 138 of them; nothing stopped the next 138 from landing.

**Why not just flip `check-links.yml` to `fail: true`?** Its own config comment says why it was switched off: rate limits and TLS resets produced ~200 false failures. Network link-checking is **non-deterministic**, so it cannot be a required check without flaking the merge queue. Flipping it would red every PR and get switched off again — which is exactly how it got here.

**Chose splitting the check by determinism** over trying to make the network check reliable. Links to paths inside the repo are decidable from the filesystem — same input, same answer, no network. That half is gated. External rot stays with the weekly lychee report, where a false positive costs a glance instead of a blocked merge.

## What is *not* counted — each exclusion is principled

Counting all 391 would make the gate a liar, because most are not ours to fix:

| Excluded | Why |
| --- | --- |
| external mirror plugins (dir has `.source.json`) | Correct in the contributor's own repo, broken only in our mirror. CLAUDE.md's never-clobber rule forbids editing them and the next sync reverts us — a gate demanding a local fix would demand a rule violation. |
| `skills/.curated/**` | Generated mirror; the plugin skill is the source of truth, and `promote-curated-check` already guards the pairing. |
| `tests/fixtures/**` | Deliberately arbitrary content; already excluded in `.lychee.toml`. |
| fenced code blocks **and inline code spans** | Skill docs teach link syntax by example — `` `[text](path)` ``, `` `[[N]](url)` ``, `` `[file](references/file.md)` ``. Illustrations, not links. Counting them would push authors to contort their own docs. Stripping inline spans alone removed **4 of the 5** remaining findings. |

## Ratcheting, not zero — baseline 1

Same contract as `scripts/lint-design-tokens.mjs`: the count may fall, never rise, and the script **refuses to raise its own baseline**.

The 1 is named in the source so nobody re-derives it — clerk-pack's `session-middleware-deep-dive.md:279` links to **itself, from inside itself**, so it resolves to `references/references/…`. It's a stray copy of the (correct) pointer in the parent `SKILL.md:52`. Not fixed here because that file is a **promoted source** whose curated mirror is byte-identical, so `promote-curated-check` requires regenerating the mirror — pack prose plus a mirror sync deserves its own review rather than riding along in a CI change.

A zero baseline would have been dishonest today, and would have tempted the next person who hit it into excluding a whole directory to get green.

## Layer touched

CI only, plus one new script. No product code, schema, or route change. **The required-status set is unchanged** — this is a step inside `validate`, which is already in `ci-required`'s `needs`, so it becomes blocking without touching branch protection. Per CLAUDE.md that is the only correct way to make a check blocking; a path-filtered workflow must never be added to the required contexts (the #778/#964 stuck-PR class).

## Verification & evidence

```
main today ..................... 1 unresolved (baseline 1) -> exit 0
re-break MAINTAINERS.md ........ 2 unresolved -> exit 1, blocks
re-break STANDARDS.md .......... exit 1, blocks
restored ....................... exit 0
workflow YAML parses; eslint clean; prettier clean
```

Both mutations were applied to real files and reverted; the gate detected each and passed clean afterward.

Also fixed while writing it: `execFileSync`'s 1 MB default `maxBuffer` overflows on this repo's tracked-markdown list (>1 MB) and threw with the entire list inside the error message.

## Risk

Low but non-zero — it is a **new blocking check**, so a false positive blocks merges. Mitigated by: deterministic-only inputs (no network), a ratcheting baseline rather than zero, and exclusions verified against the real corpus. If it misfires, the escape hatch is one line (raise `BASELINE`) and the failure mode is loud rather than silent. Rollback is reverting one commit.

## Operational impact

Negligible — one `node` invocation over tracked markdown, no network, no new dependency, no secret, no deploy ordering.

## Follow-up & deferred

- Lower `BASELINE` to 0 once the clerk-pack self-link is fixed with its curated mirror regenerated.
- Narrowing `.lychee.toml` excludes so the external half could eventually gate too — deliberately not attempted here.
- Upstreaming link/frontmatter fixes to the 33 mirror sources via the respectful-upstream flow (friendly issue first, contributor owns the PR; wording needs sign-off before posting).

Refs #1141, #1142

- Jeremy Longshore
intentsolutions.io