### PR TITLE
fix(marketplace-site): resolve the homepage version by search, not by counting directories

### DIFF
--- a/marketplace/src/pages/index.astro
+++ b/marketplace/src/pages/index.astro
@@ -10,7 +10,7 @@
 // The single hard-shadowed element on this page is the install block. That is
 // the whole design: one action, one shadow, everything else flat.
 import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
+import { dirname, join, parse } from 'node:path';
 import BaseLayout from '../layouts/BaseLayout.astro';
 import searchIndex from '../data/unified-search-index.json';
 
@@ -39,15 +39,51 @@ const installsDisplay = skillsStats.installsDisplay ?? '';
 const starsDisplay = githubStats.starsDisplay ?? '';
 
 // Marketplace version, read from the REPO ROOT package.json at build time so
-// the printed version can never drift from the released one. Read rather than
-// imported: the root manifest is outside the Astro project root, and a plain
-// file read has no bundler-resolution edge cases.
+// the printed version can never drift from the released one.
 //
-// Four levels up, not three: src/pages/ -> src/ -> marketplace/ -> repo root.
-// Three lands on marketplace/package.json, which carries its own independent
-// version (4.19.x) and is NOT the released marketplace version.
-const pkgPath = fileURLToPath(new URL('../../../../package.json', import.meta.url));
-const siteVersion = JSON.parse(readFileSync(pkgPath, 'utf8')).version as string;
+// SEARCH UPWARD BY NAME — do not count directory levels. The first cut of this
+// resolved a fixed `../../../../package.json` against `import.meta.url`, which
+// worked on a dev box and BROKE THE VPS DEPLOY (run 30776649017): during an
+// Astro build `import.meta.url` is a bundler-transformed module path, not the
+// source file's path, so its depth differs per environment. Four levels landed
+// on the repo root at `/home/jeremy/000-projects/claude-code-plugins` and on
+// nothing at `/srv/tonsofskills/build`, where readFileSync threw and took the
+// whole build down.
+//
+// Walking up until the manifest identifies ITSELF as the monorepo root is
+// depth-independent, so it cannot break again when a checkout path changes.
+// `marketplace/package.json` is correctly skipped: it carries its own
+// independent version (4.19.x) and a different name.
+const ROOT_PKG_NAME = 'claude-code-plugins-monorepo';
+
+function findRepoVersion(): string | null {
+  // process.cwd() is the Astro project dir during a build; the loop climbs out
+  // of it. Starting from cwd rather than import.meta.url is deliberate — cwd is
+  // a real filesystem location, not a bundler artefact.
+  let dir = process.cwd();
+  const { root } = parse(dir);
+  for (let i = 0; i < 12; i++) {
+    try {
+      const pkg = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8'));
+      if (pkg?.name === ROOT_PKG_NAME && typeof pkg.version === 'string') return pkg.version;
+    } catch {
+      /* no manifest here, or unreadable — keep climbing */
+    }
+    if (dir === root) break;
+    dir = dirname(dir);
+  }
+  return null;
+}
+
+// Fail soft, like every other data read on this page. A version line is nice to
+// have; it is NOT worth failing a production deploy over, which is exactly the
+// mistake this replaces. Null simply omits the line.
+let siteVersion: string | null = null;
+try {
+  siteVersion = findRepoVersion();
+} catch {
+  siteVersion = null;
+}
 
 // The Claude-Code-native slash command, and the reason this block leads with it
 // rather than a shell command: `/plugin marketplace add …` runs INSIDE Claude
@@ -81,8 +117,12 @@ const fmt = (n: number) => n.toLocaleString('en-US');
              build-time. Neither is a heading; they frame the headline. -->
         <div class="home-meta">
             <span class="home-meta-left">
-                <span class="home-version">v{siteVersion}</span>
-                <span class="home-meta-sep">·</span>
+                {siteVersion && (
+                    <>
+                        <span class="home-version">v{siteVersion}</span>
+                        <span class="home-meta-sep">·</span>
+                    </>
+                )}
                 <a href="/changelog">what&rsquo;s new &rarr;</a>
             </span>
             {starsDisplay && (


### PR DESCRIPTION
## What

The homepage resolved the repo-root `package.json` by counting directory levels. It now **searches upward for the manifest that names itself the monorepo root**, and **fails soft** — an unresolvable version omits the version line instead of throwing.

## Why

**This broke the production deploy** — run [30776649017](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/actions/runs/30776649017), the first deploy after #1152 merged.

During an Astro build, `import.meta.url` is a **bundler-transformed module path, not the source file's path**, so the distance between it and the repo root is environment-dependent:

| Environment | `../../../../package.json` resolves to | Result |
|---|---|---|
| Dev box (`/home/jeremy/000-projects/claude-code-plugins`) | the repo root | worked |
| VPS (`/srv/tonsofskills/build`) | a path that does not exist | `readFileSync` threw inside component render → build failed |

**The old form passed for the wrong reason.** `/home/jeremy/000-projects/package.json` does not exist — so if `import.meta.url` really had been the source path, four levels up would have failed locally too. Local success was an accident of how far the bundler had moved the module, not evidence of correctness. That is why local verification could not have caught it, and why the fix is depth-independence rather than a corrected count.

**Chose search-by-name over a corrected fixed hop** (e.g. `join(process.cwd(), '..')`): a fixed hop is the same bug one level shallower and breaks again the moment the Astro project moves or a deploy invokes the build from a different cwd. Matching on the manifest's own `name` is depth-independent, and correctly skips `marketplace/package.json`, which carries its own unrelated version (4.19.x).

## The real defect

Not the arithmetic — **the read was not fail-soft.** The three data reads sitting beside it (`skills-stats`, `github-stats`, `npm-stats`) all degrade to an omitted line on failure. This one could take down a production deploy. It now behaves like its neighbours.

A version string is not worth failing a deploy over. That is the lesson worth keeping from this PR.

## Blast radius — no user impact

The deploy failed **before** the rsync step, so `tonsofskills.com` kept serving the previous good build the entire time. Verified during the incident: HTTP 200, still serving pre-rebrand markup (`Inter+Tight`, `hero-search-input`). The rebrand was merged but never reached the VPS. The failure mode was safe; the pipeline did the right thing.

## Verification

| Check | Result |
|---|---|
| `npm run build` | exit 0, **3838 routes**; homepage renders `v4.33.0` |
| **Depth independence** | git worktree at `/tmp/depthtest/a/b/c/d/e/repo` — six levels deeper than the real checkout, a layout **no fixed `../` count could satisfy** — resolves `4.33.0` |
| **Fail-soft path** | from `/tmp`, outside any repo: returns `null`, template omits the line, build survives |

The middle row is the one the original change lacked. Building in one location only cannot distinguish "correct" from "coincidentally correct", so the fix is verified against a deliberately different checkout depth.

## Risk

Low and bounded. One file, frontmatter only, no markup or style change. Worst case if the search ever fails is a missing version line on the homepage — not a broken page and not a failed build, both now proven.

## Operational impact

None. No env vars, migrations, deps, secrets or deploy-order constraints. On merge, `deploy-vps.yml` re-runs and should carry the rebrand to production — the thing #1152 was blocked on.

## Follow-up

- **After merge, confirm the live site actually serves the new markup** (`install-cmd` present, `hero-search-input` absent) and that the deployed SHA matches `origin/main`. A green deploy check is not the same as a correct live page.
- Worth considering separately: the deploy job's build failure surfaced only as a truncated stack trace, because a pnpm interactive prompt overwrote the error line with a carriage return. A `--reporter=append-only` or `CI=true` on the VPS build would make the next failure legible on the first read instead of requiring log archaeology.

Refs #1152

- Jeremy Longshore
intentsolutions.io
