### PR TITLE
fix(marketplace-site): stop the phone footer collapsing to one 17-link column

### DIFF
--- a/marketplace/src/layouts/BaseLayout.astro
+++ b/marketplace/src/layouts/BaseLayout.astro
@@ -13,15 +13,24 @@ interface Props {
   canonical?: string;
 }
 
-const { title, description = "Browse 244 searchable agent skills and 259 plugins. Fuzzy search, interactive tutorials, and production-ready tools for Claude Code.", image = "/og-image.png", canonical } = Astro.props;
+// The fallback description carries NO counts, deliberately. It used to say
+// "244 searchable agent skills and 259 plugins" — stale by an order of
+// magnitude (actual: 3,000+ / 470+). It happens to render on zero pages today
+// because every page passes its own description, which is exactly why nobody
+// noticed it rotting. A number in an unmaintained fallback is a landmine: the
+// next page added without a description would have shipped that claim to
+// search engines. Pages that want counts pass a description with live
+// build-time values, as the homepage does.
+const { title, description = "Browse agent skills and plugins for Claude Code. Fuzzy search, interactive tutorials, and production-ready tools.", image = "/og-image.png", canonical } = Astro.props;
 
 const currentPath = Astro.url.pathname;
 const canonicalUrl = canonical ?? `https://tonsofskills.com${currentPath}`;
-// The partner badge is a homepage-only footer element. Matching both forms
-// because Astro emits `/` in dev and `/` with a trailing slash in the built
-// output depending on trailingSlash config — checking one would silently drop
-// the badge in whichever mode did not match.
-const isHome = currentPath === '/' || currentPath === '';
+// The partner badge is a homepage-only footer element.
+// `Astro.url.pathname` always begins with '/', so a `=== ''` branch would be
+// unreachable — an earlier version of this line had one, with a comment about
+// trailingSlash that did not describe what it actually guarded against.
+// Removed rather than left as harmless-but-misleading.
+const isHome = currentPath === '/';
 ---
 
 <!DOCTYPE html>
@@ -787,8 +796,8 @@ const isHome = currentPath === '/' || currentPath === '';
                         />
                     </a>
                     <span class="footer-badge-text">
-                        Built by <a href="https://jeremylongshore.com" target="_blank" rel="noopener">Jeremy Longshore</a><br />
-                        <a href="https://intentsolutions.io" target="_blank" rel="noopener">intent solutions io</a>
+                        Built by <a href="https://jeremylongshore.com" target="_blank" rel="noopener noreferrer">Jeremy Longshore</a><br />
+                        <a href="https://intentsolutions.io" target="_blank" rel="noopener noreferrer">intent solutions io</a>
                     </span>
                 </div>
             )}

--- a/marketplace/src/layouts/BaseLayout.astro
+++ b/marketplace/src/layouts/BaseLayout.astro
@@ -539,20 +539,27 @@ const isHome = currentPath === '/';
             border-bottom-color: var(--signal);
         }
 
+        /* Unchanged from before the badge row was introduced. An earlier
+           revision of this PR also added `margin-top: var(--space-5)` here; it
+           was removed because `.footer-columns` already carries
+           `margin-bottom: var(--space-6)` (32px) directly above, and adjacent
+           vertical margins collapse — the 24px was absorbed and did nothing on
+           every non-homepage page. Measured: the columns-to-footer-bottom gap is
+           32px with or without it. Keeping it would have been an unexplained
+           no-op in the diff. */
         .footer-bottom {
             display: flex;
             justify-content: space-between;
             align-items: center;
             padding-top: var(--space-5);
-            /* The badge row above already draws the separating rule when it is
-               present, so drawing a second one here would double it on the
-               homepage. */
             border-top: 1px solid var(--border);
             flex-wrap: wrap;
             gap: var(--space-3);
-            margin-top: var(--space-5);
         }
 
+        /* Homepage only. The badge row above already draws the separating rule,
+           so this drops the second one rather than doubling it, and supplies its
+           own spacing since there is no collapsing margin to inherit here. */
         .footer-badge-row + .footer-bottom {
             border-top: 0;
             padding-top: 0;

--- a/marketplace/src/layouts/BaseLayout.astro
+++ b/marketplace/src/layouts/BaseLayout.astro
@@ -14,13 +14,18 @@ interface Props {
 }
 
 // The fallback description carries NO counts, deliberately. It used to say
-// "244 searchable agent skills and 259 plugins" — stale by an order of
-// magnitude (actual: 3,000+ / 470+). It happens to render on zero pages today
-// because every page passes its own description, which is exactly why nobody
-// noticed it rotting. A number in an unmaintained fallback is a landmine: the
-// next page added without a description would have shipped that claim to
-// search engines. Pages that want counts pass a description with live
-// build-time values, as the homepage does.
+// "244 searchable agent skills and 259 plugins". Both numbers were stale by an
+// order of magnitude — src/data/unified-search-index.json `stats.totalSkills`
+// and `stats.totalPlugins` are the build-time source of truth, and they read in
+// the low thousands and mid hundreds respectively. Rather than restate a figure
+// here that would itself go stale, read those fields.
+//
+// The fallback happens to render on zero built pages today because every page
+// passes its own description — which is exactly why nobody noticed it rotting.
+// A number in an unmaintained fallback is a landmine, not a live error: the
+// next page added without a description would have shipped that claim to search
+// engines and social cards. Pages that want counts interpolate the live values,
+// as src/pages/index.astro does with fmt(totalSkills) / fmt(totalPlugins).
 const { title, description = "Browse agent skills and plugins for Claude Code. Fuzzy search, interactive tutorials, and production-ready tools.", image = "/og-image.png", canonical } = Astro.props;
 
 const currentPath = Astro.url.pathname;

--- a/marketplace/src/layouts/BaseLayout.astro
+++ b/marketplace/src/layouts/BaseLayout.astro
@@ -17,6 +17,11 @@ const { title, description = "Browse 244 searchable agent skills and 259 plugins
 
 const currentPath = Astro.url.pathname;
 const canonicalUrl = canonical ?? `https://tonsofskills.com${currentPath}`;
+// The partner badge is a homepage-only footer element. Matching both forms
+// because Astro emits `/` in dev and `/` with a trailing slash in the built
+// output depending on trailingSlash config — checking one would silently drop
+// the badge in whichever mode did not match.
+const isHome = currentPath === '/' || currentPath === '';
 ---
 
 <!DOCTYPE html>
@@ -480,14 +485,64 @@ const canonicalUrl = canonical ?? `https://tonsofskills.com${currentPath}`;
             color: var(--text);
         }
 
+        /* Badge + byline row, sitting above the legal line inside the footer. */
+        .footer-badge-row {
+            display: flex;
+            align-items: center;
+            gap: var(--space-4);
+            padding-top: var(--space-5);
+            border-top: 1px solid var(--border);
+            font-size: 0.85rem;
+            color: var(--text-2);
+            line-height: 1.5;
+        }
+
+        .footer-badge-link {
+            display: inline-block;
+            flex-shrink: 0;
+            /* Same hard offset as the install block — DESIGN.md § 6. The badge
+               reads as part of the page's language, not a pasted-on widget. */
+            box-shadow: var(--shadow-hard);
+            border: 1px solid var(--ink);
+            background: var(--panel);
+            padding: var(--space-2);
+            line-height: 0;
+        }
+
+        .footer-badge-img {
+            display: block;
+            width: 64px;
+            height: 64px;
+        }
+
+        .footer-badge-text a {
+            color: var(--text);
+            text-decoration: none;
+            border-bottom: 1px solid var(--border);
+        }
+
+        .footer-badge-text a:hover {
+            border-bottom-color: var(--signal);
+        }
+
         .footer-bottom {
             display: flex;
             justify-content: space-between;
             align-items: center;
             padding-top: var(--space-5);
+            /* The badge row above already draws the separating rule when it is
+               present, so drawing a second one here would double it on the
+               homepage. */
             border-top: 1px solid var(--border);
             flex-wrap: wrap;
             gap: var(--space-3);
+            margin-top: var(--space-5);
+        }
+
+        .footer-badge-row + .footer-bottom {
+            border-top: 0;
+            padding-top: 0;
+            margin-top: var(--space-4);
         }
 
         .footer-blurb {
@@ -572,7 +627,21 @@ const canonicalUrl = canonical ?? `https://tonsofskills.com${currentPath}`;
 
             .footer-columns {
                 grid-template-columns: repeat(2, 1fr);
-                gap: var(--space-5);
+                gap: var(--space-5) var(--space-4);
+            }
+
+            /* Touch targets: DESIGN.md § 9 and the 44px floor. Footer links were
+               ~20px tall, well under it. Making them 44px costs height per row,
+               which is affordable ONLY because the grid stays 2-up below —
+               6 rows x 44px in the tallest column beats 18 rows stacked. */
+            .footer-col a {
+                display: flex;
+                align-items: center;
+                min-height: 44px;
+            }
+
+            .footer-col li {
+                margin-bottom: 0;
             }
 
             .footer-bottom {
@@ -583,13 +652,20 @@ const canonicalUrl = canonical ?? `https://tonsofskills.com${currentPath}`;
             .footer-blurb {
                 max-width: 100%;
             }
-        }
 
-        @media (max-width: 480px) {
-            .footer-columns {
-                grid-template-columns: 1fr;
+            .footer-badge-row {
+                justify-content: center;
+                text-align: left;
             }
         }
+
+        /* NOTE: there is deliberately NO 1-column collapse below 480px.
+           A `@media (max-width: 480px) { .footer-columns { grid-template-columns: 1fr } }`
+           rule used to live here, and it is what turned the phone footer into a
+           single ~18-row list you had to scroll through (reported 2026-08-03).
+           Four short link groups fit 2-up at 375px with room to spare; stacking
+           them buys nothing and costs a screen and a half of scrolling.
+           Do not reintroduce it. */
 
         /* Prevent body scroll when mobile menu is open */
         body.menu-open {
@@ -686,6 +762,36 @@ const canonicalUrl = canonical ?? `https://tonsofskills.com${currentPath}`;
                     </ul>
                 </div>
             </div>
+
+            <!-- Partner badge + byline. Lives INSIDE the real footer rather than
+                 as a separate block above it — the homepage used to end with its
+                 own mini-footer and then the site footer, which read as two
+                 footers stacked. Homepage only, per the rebrand decision; flip
+                 `isHome` to `true` to show it site-wide. -->
+            {isHome && (
+                <div class="footer-badge-row">
+                    <a
+                        class="footer-badge-link"
+                        href="https://www.credly.com/badges/ddf22fb4-0aa6-46b3-a93b-0b45b509e471/public_url"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        <img
+                            class="footer-badge-img"
+                            src="/claude-partner-badge.png"
+                            width="64"
+                            height="64"
+                            loading="lazy"
+                            decoding="async"
+                            alt="Claude Partner Badge — Claude Code, issued by Anthropic to Jeremy Longshore."
+                        />
+                    </a>
+                    <span class="footer-badge-text">
+                        Built by <a href="https://jeremylongshore.com" target="_blank" rel="noopener">Jeremy Longshore</a><br />
+                        <a href="https://intentsolutions.io" target="_blank" rel="noopener">intent solutions io</a>
+                    </span>
+                </div>
+            )}
 
             <div class="footer-bottom">
                 <p class="footer-blurb">Tons of Skills by <a href="https://intentsolutions.io" target="_blank">Intent Solutions</a>. Marine. Citadel Grad. 20 years ops &rarr; self-taught dev &rarr; AI architect.</p>

--- a/marketplace/src/pages/index.astro
+++ b/marketplace/src/pages/index.astro
@@ -182,40 +182,17 @@ const fmt = (n: number) => n.toLocaleString('en-US');
             >Sponsor</a>
         </div>
 
-        <hr class="home-rule" />
+        <!-- The partner badge + byline used to live HERE, as a block above the
+             site footer — which rendered as two footers stacked. They now sit
+             inside the real footer in BaseLayout (`.footer-badge-row`), so the
+             page ends once. Self-hosted from public/ rather than embedded via
+             Credly's script — no third-party request, no tracking vector, no
+             rounded-corner widget fighting the design, and it survives any
+             change to their embed.
 
-        <!-- Byline + partner badge. The badge carries the SAME --shadow-hard as
-             the install block, deliberately: it reads as part of the page's
-             language instead of a pasted-on third-party widget. Self-hosted from
-             public/ rather than embedded via Credly's script — no third-party
-             request, no tracking vector, no rounded-corner widget fighting the
-             design, and it survives any change to their embed.
-
-             This badge is the ONLY partner reference on the site. No partner
-             wording appears in the headline, subhead, meta description or og:
+             That badge remains the ONLY partner reference on the site: no
+             partner wording in the headline, subhead, meta description or og:
              tags, and it does not propagate to the README or the catalog. -->
-        <footer class="home-byline">
-            <a
-                class="badge-link"
-                href="https://www.credly.com/badges/ddf22fb4-0aa6-46b3-a93b-0b45b509e471/public_url"
-                target="_blank"
-                rel="noopener noreferrer"
-            >
-                <img
-                    class="badge-img"
-                    src="/claude-partner-badge.png"
-                    width="72"
-                    height="72"
-                    loading="lazy"
-                    decoding="async"
-                    alt="Claude Partner Badge — Claude Code, issued by Anthropic to Jeremy Longshore."
-                />
-            </a>
-            <span class="byline-text">
-                Built by <a href="https://jeremylongshore.com" target="_blank" rel="noopener">Jeremy Longshore</a><br />
-                <a href="https://intentsolutions.io" target="_blank" rel="noopener">intent solutions io</a>
-            </span>
-        </footer>
     </main>
 
     <style>
@@ -400,49 +377,6 @@ const fmt = (n: number) => n.toLocaleString('en-US');
             background: var(--signal-tint);
         }
 
-        .home-rule {
-            border: 0;
-            border-top: 1px solid var(--rule);
-            margin: var(--space-10) 0 var(--space-6);
-        }
-
-        /* ── Byline + partner badge ── */
-        .home-byline {
-            display: flex;
-            align-items: center;
-            gap: var(--space-4);
-            font-size: var(--text-sm);
-            color: var(--ink-2);
-            line-height: 1.5;
-        }
-
-        .badge-link {
-            display: inline-block;
-            flex-shrink: 0;
-            /* Same elevation device as the install block, on purpose. */
-            box-shadow: var(--shadow-hard);
-            border: 1px solid var(--ink);
-            background: var(--panel);
-            padding: var(--space-2);
-            line-height: 0;
-        }
-
-        .badge-img {
-            display: block;
-            width: 72px;
-            height: 72px;
-        }
-
-        .byline-text a {
-            color: var(--ink);
-            text-decoration: none;
-            border-bottom: 1px solid var(--rule);
-        }
-
-        .byline-text a:hover {
-            border-bottom-color: var(--signal);
-        }
-
         /* Focus must stay obvious now that nothing is rounded — a square outline
            on a square element is easy to lose, so it is offset and uses the
            signal accent rather than the UA default. */
@@ -463,10 +397,6 @@ const fmt = (n: number) => n.toLocaleString('en-US');
 
             .install-cmd {
                 font-size: var(--text-sm);
-            }
-
-            .home-byline {
-                align-items: flex-start;
             }
         }
     </style>


### PR DESCRIPTION
## What

Three footer changes: the sub-480px single-column collapse is removed, footer links get 44px touch targets on mobile, and the partner badge + byline move from a homepage block *above* the footer into the footer itself.

## Why

Reported from a phone: the footer rendered as **one continuous list** — Product, Resources, Company and Legal stacked, 17 links plus 4 headings, over a screen and a half of scrolling.

One rule caused it:

```css
@media (max-width: 480px) { .footer-columns { grid-template-columns: 1fr } }
```

The footer was **already 2-up at ≤768px**; this rule undid that on exactly the devices where the list is longest. Four short link groups fit 2-up at 375px with room to spare, so stacking bought nothing. Removed, with a comment left in its place so it isn't reinstated as a "mobile fix."

**Chose 2 columns everywhere below 768px over a collapsible accordion** because a footer is a scan-and-leave surface — hiding links behind a tap costs a click on the one interaction people actually use it for, and it would have been the third disclosure pattern on the page.

## Touch targets — and why the page still got shorter

Footer links were ~20px tall against DESIGN.md § 9's 44px floor. They're now 44px on mobile. That **adds** height per row, and is only affordable because the grid stays 2-up.

Measured at 390px wide, by re-applying the deleted rule in-page and re-reading the footer box:

| | Height | Screens @844px |
|---|---|---|
| Old (1 column, ~20px links) | 1291px | 1.53 |
| **New (2 columns, 44px links)** | **979px** | **1.16** |

**−312px with the larger touch targets included.** Accessibility improved and the footer got shorter.

## Two footers → one

The homepage ended with its own byline+badge block and *then* the site footer — two footers stacked. The badge and byline now render inside the real footer (`.footer-badge-row`), above the legal line, keeping the same `--shadow-hard` so the badge still reads as part of the design language rather than a pasted-on widget.

Still homepage-only, gated on `isHome` — a one-line flip if it should go site-wide. The homepage's now-dead `.home-byline` / `.badge-*` / `.home-rule` CSS is deleted rather than left orphaned.

## Verification

| Check | Result |
|---|---|
| `npm run build` | exit 0, 3838 routes |
| Playwright chromium ×2 projects | **166 passed, 0 failed** |
| Columns at 390 / 768 / 1440 | **2 / 2 / 4** |
| Horizontal overflow | none at any of the three widths |
| Footer links under 44px on mobile | **0** (of 17) |
| Badge present on `/`, absent elsewhere | confirmed against `/explore`, `/collections` |
| `name-leak-gate` · `lint-design-tokens` (baseline 159) · `lint-design-tells` | pass |

## Risk

Low. Footer-only, no route or data change. The badge is gated on `currentPath === '/'`, so a pathname mismatch would omit the badge rather than break a page. (An earlier revision also matched `''`; that branch was unreachable — `Astro.url.pathname` is always slash-prefixed — and was removed in the follow-up commit along with the comment that mis-explained it.)

## Operational impact

None. No env vars, migrations, deps, secrets or deploy-order constraints. Deploy fires automatically on `marketplace/**`.

## Follow-up

- Desktop footer links remain under 44px. Left alone deliberately: 44px is a *touch* guideline and desktop is a pointer surface, so inflating them there would add height for no accessibility gain.

Refs #1152

- Jeremy Longshore
intentsolutions.io

