### PR TITLE
fix(marketplace-site): load design tokens on /research/ so its var(--*) actually resolve

### DIFF
--- a/marketplace/src/components/ResearchTemplate.astro
+++ b/marketplace/src/components/ResearchTemplate.astro
@@ -7,9 +7,20 @@ interface Props {
   wordCount: number;
 }
 
-// Bundled by Astro and emitted as a hashed /_astro/ asset — replaces the
-// `<link href="/styles/global.css">` that 404'd, since src/styles is a source
-// directory and was never copied to public/.
+// tokens.css FIRST, then global.css. Both are bundled by Astro into a hashed
+// /_astro/ asset, replacing the `<link href="/styles/global.css">` that 404'd
+// (src/styles is a source directory and was never copied to public/).
+//
+// tokens.css is not optional here and its absence is not cosmetic. Verified on
+// the deployed page: with only global.css, `--font-sans`, `--bg` and `--ink`
+// all resolved to (UNDEFINED) — global.css and this component's own styles are
+// written entirely in `var(--*)`, so EVERY one of those declarations was
+// invalid. The six /research/ pages rendered with no design system at all:
+// Times New Roman on a transparent background.
+//
+// BaseLayout gets these via `@import '../styles/tokens.css'` inside its
+// <style>; this template does not use BaseLayout, so it has to ask for them.
+import '../styles/tokens.css';
 import '../styles/global.css';
 
 const { title, description, domain, domainSlug, wordCount } = Astro.props;


### PR DESCRIPTION
## What

`ResearchTemplate.astro` now imports `tokens.css` alongside `global.css`.

## Why

#1156 replaced this template's 404ing `<link href="/styles/global.css">` with a bundled import and added the webfont. **Verifying the deployed page rather than the diff showed that wasn't enough:**

```
--font-sans : (UNDEFINED)
--bg        : (UNDEFINED)
--ink       : (UNDEFINED)
body font   : "Times New Roman"
body bg     : rgba(0, 0, 0, 0)
```

`global.css` and this component's own ~300 lines of styles are written almost entirely in `var(--*)`, and every one of those custom properties is **defined in `tokens.css`**. Without it the declarations are invalid and drop — so the six `/research/` pages rendered with **no design system at all**: browser-default serif on a transparent background, while loading a font they never applied.

`BaseLayout` gets tokens via `@import '../styles/tokens.css'` inside its `<style>`. This template doesn't use `BaseLayout`, so nothing supplied them. Import order is tokens-then-global because global consumes what tokens defines.

**The lesson worth keeping:** loading a font is not the same as applying one, and *"I added the stylesheet link"* is not evidence the page is styled. The previous fix looked complete in the diff **and** in the built HTML. Only reading computed values off the rendered page showed the difference.

## Verification — computed values on the rendered page

| | Before | After |
|---|---|---|
| `--font-sans` | `(UNDEFINED)` | `"JetBrains Mono", "SF Mono", …` |
| `--bg` | `(UNDEFINED)` | `oklch(14.574% .0043 285.86)` |
| `--ink` | `(UNDEFINED)` | `oklch(96.743% .0013 286.38)` |
| body font | **Times New Roman** | JetBrains Mono |
| body background | transparent | `oklch(0.14574 0.0043 285.86)` |

Plus: `npm run build` exit 0 (3,838 routes) · Playwright chromium ×2 **166 passed, 0 failed** · `lint-design-tokens` at baseline 159 · `name-leak-gate` clean.

## Risk

Low and strictly additive — one extra bundled stylesheet on six pages that previously had no working tokens. Nothing else imports this template.

## Operational impact

None. Deploy fires automatically on `marketplace/**`.

## Follow-up

`ResearchTemplate.astro` is effectively a fork of `BaseLayout` — it re-declares `<head>`, nav, and footer, which is why it kept drifting out of sync (404 stylesheet, no font, no analytics, no tokens: four separate omissions, all from the same root cause). Folding it into `BaseLayout` would remove the whole class. Deliberately not done here — that's a redesign of six pages and belongs in its own PR with its own visual review.

Refs #1156

- Jeremy Longshore
intentsolutions.io
